### PR TITLE
fix race condition in tcp_client::connect

### DIFF
--- a/sources/network/tcp_client.cpp
+++ b/sources/network/tcp_client.cpp
@@ -30,12 +30,11 @@ tcp_client::connect(const std::string& host, unsigned int port) {
 
     //! async connect
     m_socket.async_connect(endpoint, [&](boost::system::error_code error) {
-        conn_cond_var.notify_one();
-
         if (not error) {
             m_is_connected = true;
             async_read();
         }
+        conn_cond_var.notify_one();
     });
 
     //! start loop and wait for async connect result


### PR DESCRIPTION
There is a race in the TCP client when connecting to the Redis host. The std::condition_variable is notified before the m_is_connected boolean is toggled possibly causing the connection to fail. This appears to happen very frequently in my setup.