### PR TITLE
Ignoring Makefile created by CMake process.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ CMakeCache.txt
 CMakeFiles/
 Release/
 Debug/
+Makefile


### PR DESCRIPTION
By doing so, we make sure that the process of building the code does not imply a change to the git repository itself.