### PR TITLE
allow custom callback before calling reply_callback_t

### DIFF
--- a/includes/cpp_redis/redis_client.hpp
+++ b/includes/cpp_redis/redis_client.hpp
@@ -32,6 +32,7 @@ public:
 
   //! send cmd
   typedef std::function<void(reply&)> reply_callback_t;
+  redis_client& before_callback(const std::function<void(reply&, const reply_callback_t& callback)>& callback);
   redis_client& send(const std::vector<std::string>& redis_cmd, const reply_callback_t& callback = nullptr);
 
   //! commit pipelined transaction
@@ -277,6 +278,9 @@ private:
 
   //! user defined disconnection handler
   disconnection_handler_t m_disconnection_handler;
+
+  //! user defined before callback handler
+  std::function<void(reply&, reply_callback_t& callback)> m_before_callback_handler;
 
   //! thread safety
   std::mutex m_callbacks_mutex;

--- a/sources/redis_client.cpp
+++ b/sources/redis_client.cpp
@@ -72,6 +72,11 @@ redis_client::sync_commit(void) {
   return *this;
 }
 
+redis_client& redis_client::before_callback(const std::function<void(reply&, const reply_callback_t& callback)>& callback) {
+	m_before_callback_handler = callback;
+	return *this;
+}
+
 void
 redis_client::try_commit(void) {
   try {
@@ -101,7 +106,10 @@ redis_client::connection_receive_handler(network::redis_connection&, reply& repl
     }
   }
 
-  if (callback) {
+  if (m_before_callback_handler) {
+    __CPP_REDIS_LOG(debug, "cpp_redis::redis_client executes reply callback through custom before callback handler");
+    m_before_callback_handler(reply, callback);
+  } else if (callback) {
     __CPP_REDIS_LOG(debug, "cpp_redis::redis_client executes reply callback");
     callback(reply);
   }


### PR DESCRIPTION
`cpp_redis::redis_client` is not single threaded, meaning that the callback could be called from the `io_service` threads. Allowing a custom callback to call `reply_callback_t` can be handy when you need thread-safety.

**Example when the current approach could fail:**
```cpp
my_http_server.get("/user", [](request& req, reply& rep) {
    // This is handled in the http_server_thread
    redis.get("session_hash:" + req.session, [rep](cpp_redis::reply& rep) {
        // This is handled in the redis_client_thread! :(
        rep.send(rep.as_string());
    }
});
```

**How the proposed change can help:**
```cpp
// Sets a before callback for cpp_redis::redis_client
redis.before_callback([this](cpp_redis::reply& reply, const cpp_redis::redis_client::reply_callback_t& callback) {
  // Thread-safely enqueue the reply in the http server queue
  my_http_server.enqueue_redis_reply(reply, callback);
});
...
// Handle enqueued-replies
void MyHttpServer::repliesHandler() {
   while (!replies.empty()) {
      RedisReplyCallback* r = replies.front();
      if (r->callback) {
          r->callback(rep->reply);
      }

      replies.pop();
   }
}
...
my_http_server.get("/user", [](request& req, reply& rep) {
    // This is handled in the http_server_thread
    redis.get("session_hash:" + req.session, [rep](cpp_redis::reply& rep) {
        // Now this is also handled in the http_server_thread!
        // Because it's being called from the MyHttpServer::repliesHandler!
        rep.send(rep.as_string());
    }
});```