### PR TITLE
Generate pkg-config File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 build
 deps
 target
+lib
 
 # Executables
 *.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,13 @@ endforeach()
 ###
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_PKGCONFIG_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/pkgconfig)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+###
+# pkg-config
+###
+configure_file("cpp_redis.pc.in" "${CMAKE_PKGCONFIG_OUTPUT_DIRECTORY}/cpp_redis.pc" @ONLY)
 
 ###
 # executable

--- a/cpp_redis.pc.in
+++ b/cpp_redis.pc.in
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: @PROJECT_NAME@
+Description: C++11 Lightweight Redis client: async, thread-safe, no dependency, pipelining, multi-platform.
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -lcpp_redis
+Cflags: -I${includedir}


### PR DESCRIPTION
[pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config) is a common tool to generate compiler flags for libraries on a system. This PR adds the relevant config file so other projects can use pkg-config to discover where cpp_redis has been installed to.