### PR TITLE
Added future and sync clients

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,6 +19,12 @@ include_directories(${PROJECT_SOURCE_DIR}/includes
 add_executable(redis_client redis_client.cpp)
 target_link_libraries(redis_client cpp_redis)
 
+add_executable(future_client future_client.cpp)
+target_link_libraries(future_client cpp_redis)
+
+add_executable(sync_client sync_client.cpp)
+target_link_libraries(sync_client cpp_redis)
+
 add_executable(redis_subscriber redis_subscriber.cpp)
 target_link_libraries(redis_subscriber cpp_redis)
 

--- a/examples/future_client.cpp
+++ b/examples/future_client.cpp
@@ -1,0 +1,30 @@
+#include <cpp_redis/cpp_redis>
+
+#include <iostream>
+
+int
+main(void) {
+  //! Enable logging
+  cpp_redis::active_logger = std::unique_ptr<cpp_redis::logger>(new cpp_redis::logger);
+
+  cpp_redis::future_client client;
+
+  client.connect("127.0.0.1", 6379, [](cpp_redis::redis_client&) {
+    std::cout << "client disconnected (disconnection handler)" << std::endl;
+  });
+
+  //! Set a value
+  auto tok = client.set("hello", "42");
+  std::cout << "set 'hello' 42: " << tok.get() << std::endl;
+
+  //! Decrement the value
+  cpp_redis::reply r = client.decrby("hello", 12).get();
+  if (r.is_integer())
+    std::cout << "After 'hello' decrement by 12: " << r.as_integer() << std::endl;
+
+  //! Read the value again
+  tok = client.get("hello");
+  std::cout << "get 'hello': " << tok.get() << std::endl;
+
+  return 0;
+}

--- a/examples/sync_client.cpp
+++ b/examples/sync_client.cpp
@@ -1,0 +1,26 @@
+#include <cpp_redis/cpp_redis>
+
+#include <iostream>
+
+int
+main(void) {
+  //! Enable logging
+  cpp_redis::active_logger = std::unique_ptr<cpp_redis::logger>(new cpp_redis::logger);
+
+  cpp_redis::sync_client client;
+
+  client.connect("127.0.0.1", 6379, [](cpp_redis::redis_client&) {
+    std::cout << "client disconnected (disconnection handler)" << std::endl;
+  });
+
+  cpp_redis::reply r = client.set("hello", "42");
+  std::cout << "set 'hello' 42: " << r << std::endl;
+
+  r = client.decrby("hello", 12);
+  std::cout << "decrby 'hello' 12: " << r << std::endl;
+
+  r = client.get("hello");
+  std::cout << "get 'hello': " << r << std::endl;
+
+  return 0;
+}

--- a/includes/cpp_redis/cpp_redis
+++ b/includes/cpp_redis/cpp_redis
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cpp_redis/redis_client.hpp>
+#include <cpp_redis/future_client.hpp>
+#include <cpp_redis/sync_client.hpp>
 #include <cpp_redis/redis_subscriber.hpp>
 #include <cpp_redis/reply.hpp>
 #include <cpp_redis/redis_error.hpp>

--- a/includes/cpp_redis/future_client.hpp
+++ b/includes/cpp_redis/future_client.hpp
@@ -1,0 +1,638 @@
+#pragma once
+
+#include <future>
+#include <functional>
+#include <memory>
+
+#include <cpp_redis/logger.hpp>
+#include <cpp_redis/redis_client.hpp>
+
+namespace cpp_redis {
+
+class future_client {
+
+public:
+  using result_type = reply;
+  using promise = std::promise<result_type>;
+  using future = std::future<result_type>;
+  using reply_callback_t = redis_client::reply_callback_t;
+  using disconnection_handler_t = redis_client::disconnection_handler_t;
+
+private:
+  using rc = redis_client;
+  using rcb_t = reply_callback_t;
+
+  using call_t = std::function<rc&(const reply_callback_t&)>;
+
+  //! Execute a command on the redis_client and tie the callback to a future
+  future exec_cmd(call_t f) {
+    auto prms = std::make_shared<promise>();
+    f([prms](reply& reply) {
+      prms->set_value(reply);
+    }).commit();
+    return prms->get_future();
+  }
+
+public:
+  //! ctor & dtor
+  future_client(const std::shared_ptr<network::io_service>& IO = nullptr);
+  ~future_client(void);
+
+  void connect(const std::string& host = "127.0.0.1", std::size_t port = 6379,
+               const disconnection_handler_t& disconnection_handler = nullptr) {
+    m_client.connect(host, port, disconnection_handler);
+  }
+  void disconnect() { m_client.disconnect(); }
+  bool is_connected() { return m_client.is_connected(); }
+
+
+  future append(const std::string& key, const std::string& value) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.append(key, value, cb);});
+  }
+  future auth(const std::string& password) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.auth(password, cb);});
+  }
+  future bgrewriteaof() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.bgrewriteaof(cb);});
+  }
+  future bgsave() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.bgsave(cb);});
+  }
+  future bitcount(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.bitcount(key, cb);});
+  }
+  future bitcount(const std::string& key, int start, int end) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.bitcount(key, start, end, cb);});
+  }
+  // future bitfield(const std::string& key) key [get type offset] [set type offset value] [incrby type offset increment] [overflow wrap|sat|fail]
+  future bitop(const std::string& operation, const std::string& destkey, const std::vector<std::string>& keys) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.bitop(operation, destkey, keys, cb);});
+  }
+  future bitpos(const std::string& key, int bit) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.bitpos(key, bit, cb);});
+  }
+  future bitpos(const std::string& key, int bit, int start) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.bitpos(key, bit, start, cb);});
+  }
+  future bitpos(const std::string& key, int bit, int start, int end) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.bitpos(key, bit, start, end, cb);});
+  }
+  future blpop(const std::vector<std::string>& keys, int timeout) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.blpop(keys, timeout, cb);});
+  }
+  future brpop(const std::vector<std::string>& keys, int timeout) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.brpop(keys, timeout, cb);});
+  }
+  future brpoplpush(const std::string& src, const std::string& dst, int timeout) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.brpoplpush(src, dst, timeout, cb);});
+  }
+  // future client_kill() [ip:port] [id client-id] [type normal|master|slave|pubsub] [addr ip:port] [skipme yes/no]
+  future client_list() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.client_list(cb);});
+  }
+  future client_getname() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.client_getname(cb);});
+  }
+  future client_pause(int timeout) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.client_pause(timeout, cb);});
+  }
+  future client_reply(const std::string& mode) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.client_reply(mode, cb);});
+  }
+  future client_setname(const std::string& name) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.client_setname(name, cb);});
+  }
+  future cluster_addslots(const std::vector<std::string>& slots) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_addslots(slots, cb);});
+  }
+  future cluster_count_failure_reports(const std::string& node_id) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_count_failure_reports(node_id, cb);});
+  }
+  future cluster_countkeysinslot(const std::string& slot) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_countkeysinslot(slot, cb);});
+  }
+  future cluster_delslots(const std::vector<std::string>& slots) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_delslots(slots, cb);});
+  }
+  future cluster_failover() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_failover(cb);});
+  }
+  future cluster_failover(const std::string& mode) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_failover(mode, cb);});
+  }
+  future cluster_forget(const std::string& node_id) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_forget(node_id, cb);});
+  }
+  future cluster_getkeysinslot(const std::string& slot, int count) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_getkeysinslot(slot, count, cb);});
+  }
+  future cluster_info() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_info(cb);});
+  }
+  future cluster_keyslot(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_keyslot(key, cb);});
+  }
+  future cluster_meet(const std::string& ip, int port) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_meet(ip, port, cb);});
+  }
+  future cluster_nodes() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_nodes(cb);});
+  }
+  future cluster_replicate(const std::string& node_id) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_replicate(node_id, cb);});
+  }
+  future cluster_reset(const std::string& mode = "soft") {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_reset(mode, cb);});
+  }
+  future cluster_saveconfig() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_saveconfig(cb);});
+  }
+  future cluster_set_config_epoch(const std::string& epoch) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_set_config_epoch(epoch, cb);});
+  }
+  future cluster_setslot(const std::string& slot, const std::string& mode) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_setslot(slot, mode, cb);});
+  }
+  future cluster_setslot(const std::string& slot, const std::string& mode, const std::string& node_id) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_setslot(slot, mode, node_id, cb);});
+  }
+  future cluster_slaves(const std::string& node_id) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_slaves(node_id, cb);});
+  }
+  future cluster_slots() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.cluster_slots(cb);});
+  }
+  future command() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.command(cb);});
+  }
+  future command_count() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.command_count(cb);});
+  }
+  future command_getkeys() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.command_getkeys(cb);});
+  }
+  future command_info(const std::vector<std::string>& command_name) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.command_info(command_name, cb);});
+  }
+  future config_get(const std::string& param) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.config_get(param, cb);});
+  }
+  future config_rewrite() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.config_rewrite(cb);});
+  }
+  future config_set(const std::string& param, const std::string& val) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.config_set(param, val, cb);});
+  }
+  future config_resetstat() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.config_resetstat(cb);});
+  }
+  future dbsize() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.dbsize(cb);});
+  }
+  future debug_object(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.debug_object(key, cb);});
+  }
+  future debug_segfault() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.debug_segfault(cb);});
+  }
+  future decr(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.decr(key, cb);});
+  }
+  future decrby(const std::string& key, int val) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.decrby(key, val, cb);});
+  }
+  future del(const std::vector<std::string>& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.del(key, cb);});
+  }
+  future discard() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.discard(cb);});
+  }
+  future dump(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.dump(key, cb);});
+  }
+  future echo(const std::string& msg) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.echo(msg, cb);});
+  }
+  future eval(const std::string& script, int numkeys, const std::vector<std::string>& keys, const std::vector<std::string>& args) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.eval(script, numkeys, keys, args, cb);});
+  }
+  future evalsha(const std::string& sha1, int numkeys, const std::vector<std::string>& keys, const std::vector<std::string>& args) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.evalsha(sha1, numkeys, keys, args, cb);});
+  }
+  future exec() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.exec(cb);});
+  }
+  future exists(const std::vector<std::string>& keys) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.exists(keys, cb);});
+  }
+  future expire(const std::string& key, int seconds) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.expire(key, seconds, cb);});
+  }
+  future expireat(const std::string& key, int timestamp) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.expireat(key, timestamp, cb);});
+  }
+  future flushall() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.flushall(cb);});
+  }
+  future flushdb() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.flushdb(cb);});
+  }
+  future geoadd(const std::string& key, const std::vector<std::tuple<std::string, std::string, std::string>>& long_lat_memb) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.geoadd(key, long_lat_memb, cb);});
+  }
+  future geohash(const std::string& key, const std::vector<std::string>& members) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.geohash(key, members, cb);});
+  }
+  future geopos(const std::string& key, const std::vector<std::string>& members) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.geopos(key, members, cb);});
+  }
+  future geodist(const std::string& key, const std::string& member_1, const std::string& member_2, const std::string& unit = "m") {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.geodist(key, member_1, member_2, unit, cb);});
+  }
+  // future georadius() key longitude latitude radius m|km|ft|mi [withcoord] [withdist] [withhash] [count count] [asc|desc] [store key] [storedist key]
+  // future georadiusbymember() key member radius m|km|ft|mi [withcoord] [withdist] [withhash] [count count] [asc|desc] [store key] [storedist key]
+  future get(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.get(key, cb);});
+  }
+  future getbit(const std::string& key, int offset) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.getbit(key, offset, cb);});
+  }
+  future getrange(const std::string& key, int start, int end) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.getrange(key, start, end, cb);});
+  }
+  future getset(const std::string& key, const std::string& val) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.getset(key, val, cb);});
+  }
+  future hdel(const std::string& key, const std::vector<std::string>& fields) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.hdel(key, fields, cb);});
+  }
+  future hexists(const std::string& key, const std::string& field) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.hexists(key, field, cb);});
+  }
+  future hget(const std::string& key, const std::string& field) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.hget(key, field, cb);});
+  }
+  future hgetall(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.hgetall(key, cb);});
+  }
+  future hincrby(const std::string& key, const std::string& field, int incr) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.hincrby(key, field, incr, cb);});
+  }
+  future hincrbyfloat(const std::string& key, const std::string& field, float incr) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.hincrbyfloat(key, field, incr, cb);});
+  }
+  future hkeys(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.hkeys(key, cb);});
+  }
+  future hlen(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.hlen(key, cb);});
+  }
+  future hmget(const std::string& key, const std::vector<std::string>& fields) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.hmget(key, fields, cb);});
+  }
+  future hmset(const std::string& key, const std::vector<std::pair<std::string, std::string>>& field_val) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.hmset(key, field_val, cb);});
+  }
+  future hset(const std::string& key, const std::string& field, const std::string& value) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.hset(key, field, value, cb);});
+  }
+  future hsetnx(const std::string& key, const std::string& field, const std::string& value) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.hsetnx(key, field, value, cb);});
+  }
+  future hstrlen(const std::string& key, const std::string& field) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.hstrlen(key, field, cb);});
+  }
+  future hvals(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.hvals(key, cb);});
+  }
+  future incr(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.incr(key, cb);});
+  }
+  future incrby(const std::string& key, int incr) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.incrby(key, incr, cb);});
+  }
+  future incrbyfloat(const std::string& key, float incr) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.incrbyfloat(key, incr, cb);});
+  }
+  future info(const std::string& section = "default") {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.info(section, cb);});
+  }
+  future keys(const std::string& pattern) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.keys(pattern, cb);});
+  }
+  future lastsave() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.lastsave(cb);});
+  }
+  future lindex(const std::string& key, int index) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.lindex(key, index, cb);});
+  }
+  future linsert(const std::string& key, const std::string& before_after, const std::string& pivot, const std::string& value) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.linsert(key, before_after, pivot, value, cb);});
+  }
+  future llen(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.llen(key, cb);});
+  }
+  future lpop(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.lpop(key, cb);});
+  }
+  future lpush(const std::string& key, const std::vector<std::string>& values) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.lpush(key, values, cb);});
+  }
+  future lpushx(const std::string& key, const std::string& value) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.lpushx(key, value, cb);});
+  }
+  future lrange(const std::string& key, int start, int stop) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.lrange(key, start, stop, cb);});
+  }
+  future lrem(const std::string& key, int count, const std::string& value) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.lrem(key, count, value, cb);});
+  }
+  future lset(const std::string& key, int index, const std::string& value) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.lset(key, index, value, cb);});
+  }
+  future ltrim(const std::string& key, int start, int stop) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.ltrim(key, start, stop, cb);});
+  }
+  future mget(const std::vector<std::string>& keys) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.mget(keys, cb);});
+  }
+  future migrate(const std::string& host, int port, const std::string& key, const std::string& dest_db, int timeout, bool copy = false, bool replace = false, const std::vector<std::string>& keys = {}) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.migrate(host, port, key, dest_db, timeout, copy, replace, keys, cb);});
+  }
+  future monitor() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.monitor(cb);});
+  }
+  future move(const std::string& key, const std::string& db) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.move(key, db, cb);});
+  }
+  future mset(const std::vector<std::pair<std::string, std::string>>& key_vals) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.mset(key_vals, cb);});
+  }
+  future msetnx(const std::vector<std::pair<std::string, std::string>>& key_vals) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.msetnx(key_vals, cb);});
+  }
+  future multi() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.multi(cb);});
+  }
+  future object(const std::string& subcommand, const std::vector<std::string>& args) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.object(subcommand, args, cb);});
+  }
+  future persist(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.persist(key, cb);});
+  }
+  future pexpire(const std::string& key, int milliseconds) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.pexpire(key, milliseconds, cb);});
+  }
+  future pexpireat(const std::string& key, int milliseconds_timestamp) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.pexpireat(key, milliseconds_timestamp, cb);});
+  }
+  future pfadd(const std::string& key, const std::vector<std::string>& elements) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.pfadd(key, elements, cb);});
+  }
+  future pfcount(const std::vector<std::string>& keys) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.pfcount(keys, cb);});
+  }
+  future pfmerge(const std::string& destkey, const std::vector<std::string>& sourcekeys) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.pfmerge(destkey, sourcekeys, cb);});
+  }
+  future ping() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.ping(cb);});
+  }
+  future ping(const std::string& message) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.ping(message, cb);});
+  }
+  future psetex(const std::string& key, int milliseconds, const std::string& val) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.psetex(key, milliseconds, val, cb);});
+  }
+  future publish(const std::string& channel, const std::string& message) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.publish(channel, message, cb);});
+  }
+  future pubsub(const std::string& subcommand, const std::vector<std::string>& args) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.pubsub(subcommand, args, cb);});
+  }
+  future pttl(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.pttl(key, cb);});
+  }
+  future quit() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.quit(cb);});
+  }
+  future randomkey() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.randomkey(cb);});
+  }
+  future readonly() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.readonly(cb);});
+  }
+  future readwrite() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.readwrite(cb);});
+  }
+  future rename(const std::string& key, const std::string& newkey) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.rename(key, newkey, cb);});
+  }
+  future renamenx(const std::string& key, const std::string& newkey) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.renamenx(key, newkey, cb);});
+  }
+  future restore(const std::string& key, int ttl, const std::string& serialized_value) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.restore(key, ttl, serialized_value, cb);});
+  }
+  future restore(const std::string& key, int ttl, const std::string& serialized_value, const std::string& replace) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.restore(key, ttl, serialized_value, replace, cb);});
+  }
+  future role() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.role(cb);});
+  }
+  future rpop(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.rpop(key, cb);});
+  }
+  future rpoplpush(const std::string& src, const std::string& dst) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.rpoplpush(src, dst, cb);});
+  }
+  future rpush(const std::string& key, const std::vector<std::string>& values) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.rpush(key, values, cb);});
+  }
+  future rpushx(const std::string& key, const std::string& value) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.rpushx(key, value, cb);});
+  }
+  future sadd(const std::string& key, const std::vector<std::string>& members) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.sadd(key, members, cb);});
+  }
+  future save() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.save(cb);});
+  }
+  future scard(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.scard(key, cb);});
+  }
+  future script_debug(const std::string& mode) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.script_debug(mode, cb);});
+  }
+  future script_exists(const std::vector<std::string>& scripts) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.script_exists(scripts, cb);});
+  }
+  future script_flush() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.script_flush(cb);});
+  }
+  future script_kill() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.script_kill(cb);});
+  }
+  future script_load(const std::string& script) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.script_load(script, cb);});
+  }
+  future sdiff(const std::vector<std::string>& keys) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.sdiff(keys, cb);});
+  }
+  future sdiffstore(const std::string& dst, const std::vector<std::string>& keys) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.sdiffstore(dst, keys, cb);});
+  }
+  future select(int index) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.select(index, cb);});
+  }
+  future set(const std::string& key, const std::string& value) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.set(key, value, cb);});
+  }
+  future set_advanced(const std::string& key, const std::string& value, bool ex = false, int ex_sec = 0, bool px = false, int px_milli = 0, bool nx = false, bool xx = false) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.set_advanced(key, value, ex, ex_sec, px, px_milli, nx, xx, cb);});
+  }
+  future setbit(const std::string& key, int offset, const std::string& value) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.setbit(key, offset, value, cb);});
+  }
+  future setex(const std::string& key, int seconds, const std::string& value) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.setex(key, seconds, value, cb);});
+  }
+  future setnx(const std::string& key, const std::string& value) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.setnx(key, value, cb);});
+  }
+  future setrange(const std::string& key, int offset, const std::string& value) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.setrange(key, offset, value, cb);});
+  }
+  future shutdown() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.shutdown(cb);});
+  }
+  future shutdown(const std::string& save) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.shutdown(save, cb);});
+  }
+  future sinter(const std::vector<std::string>& keys) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.sinter(keys, cb);});
+  }
+  future sinterstore(const std::string& dst, const std::vector<std::string>& keys) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.sinterstore(dst, keys, cb);});
+  }
+  future sismember(const std::string& key, const std::string& member) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.sismember(key, member, cb);});
+  }
+  future slaveof(const std::string& host, int port) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.slaveof(host, port, cb);});
+  }
+  future slowlog(const std::string& subcommand) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.slowlog(subcommand, cb);});
+  }
+  future slowlog(const std::string& subcommand, const std::string& argument) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.slowlog(subcommand, argument, cb);});
+  }
+  future smembers(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.smembers(key, cb);});
+  }
+  future smove(const std::string& src, const std::string& dst, const std::string& member) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.smove(src, dst, member, cb);});
+  }
+  // future sort() key [by pattern] [limit offset count] [get pattern [get pattern ...]] [asc|desc] [alpha] [store destination]
+  future spop(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.spop(key, cb);});
+  }
+  future spop(const std::string& key, int count) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.spop(key, count, cb);});
+  }
+  future srandmember(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.srandmember(key, cb);});
+  }
+  future srandmember(const std::string& key, int count) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.srandmember(key, count, cb);});
+  }
+  future srem(const std::string& key, const std::vector<std::string>& members) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.srem(key, members, cb);});
+  }
+  future strlen(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.strlen(key, cb);});
+  }
+  future sunion(const std::vector<std::string>& keys) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.sunion(keys, cb);});
+  }
+  future sunionstore(const std::string& dst, const std::vector<std::string>& keys) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.sunionstore(dst, keys, cb);});
+  }
+  future sync() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.sync(cb);});
+  }
+  future time() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.time(cb);});
+  }
+  future ttl(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.ttl(key, cb);});
+  }
+  future type(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.type(key, cb);});
+  }
+  future unwatch() {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.unwatch(cb);});
+  }
+  future wait(int numslaves, int timeout) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.wait(numslaves, timeout, cb);});
+  }
+  future watch(const std::vector<std::string>& keys) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.watch(keys, cb);});
+  }
+  // future zadd() key [nx|xx] [ch] [incr] score member [score member ...]
+  future zcard(const std::string& key) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.zcard(key, cb);});
+  }
+  future zcount(const std::string& key, int min, int max) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.zcount(key, min, max, cb);});
+  }
+  future zincrby(const std::string& key, int incr, const std::string& member) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.zincrby(key, incr, member, cb);});
+  }
+  // future zinterstore() destination numkeys key [key ...] [weights weight [weight ...]] [aggregate sum|min|max]
+  future zlexcount(const std::string& key, int min, int max) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.zlexcount(key, min, max, cb);});
+  }
+  future zrange(const std::string& key, int start, int stop, bool withscores = false) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.zrange(key, start, stop, withscores, cb);});
+  }
+  // future zrangebylex() key min max [limit offset count]
+  // future zrevrangebylex() key max min [limit offset count]
+  // future zrangebyscore() key min max [withscores] [limit offset count]
+  future zrank(const std::string& key, const std::string& member) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.zrank(key, member, cb);});
+  }
+  future zrem(const std::string& key, const std::vector<std::string>& members) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.zrem(key, members, cb);});
+  }
+  future zremrangebylex(const std::string& key, int min, int max) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.zremrangebylex(key, min, max, cb);});
+  }
+  future zremrangebyrank(const std::string& key, int start, int stop) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.zremrangebyrank(key, start, stop, cb);});
+  }
+  future zremrangebyscore(const std::string& key, int min, int max) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.zremrangebyscore(key, min, max, cb);});
+  }
+  future zrevrange(const std::string& key, int start, int stop, bool withscores = false) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.zrevrange(key, start, stop, withscores, cb);});
+  }
+  // future zrevrangebyscore() key max min [withscores] [limit offset count]
+  future zrevrank(const std::string& key, const std::string& member) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.zrevrank(key, member, cb);});
+  }
+  future zscore(const std::string& key, const std::string& member) {
+    return exec_cmd([=](const rcb_t& cb) -> rc& {return m_client.zscore(key, member, cb);});
+  }
+  // future zunionstore() destination numkeys key [key ...] [weights weight [weight ...]] [aggregate sum|min|max]
+  // future scan() cursor [match pattern] [count count]
+  // future sscan() key cursor [match pattern] [count count]
+  // future hscan() key cursor [match pattern] [count count]
+  // future zscan() key cursor [match pattern] [count count]
+
+private:
+  redis_client m_client;
+};
+
+} //! cpp_redis
+

--- a/includes/cpp_redis/sync_client.hpp
+++ b/includes/cpp_redis/sync_client.hpp
@@ -1,0 +1,619 @@
+#pragma once
+
+#include <cpp_redis/logger.hpp>
+#include <cpp_redis/future_client.hpp>
+
+namespace cpp_redis {
+
+class sync_client {
+
+public:
+  using result_type = reply;
+  using disconnection_handler_t = redis_client::disconnection_handler_t;
+
+public:
+  //! ctor & dtor
+  sync_client(const std::shared_ptr<network::io_service>& IO = nullptr);
+  ~sync_client(void);
+
+  void connect(const std::string& host = "127.0.0.1", std::size_t port = 6379,
+               const disconnection_handler_t& disconnection_handler = nullptr) {
+    m_client.connect(host, port, disconnection_handler);
+  }
+  void disconnect() { m_client.disconnect(); }
+  bool is_connected() { return m_client.is_connected(); }
+#if 0
+ {
+    return m_client.().get();
+  }
+#endif
+  reply append(const std::string& key, const std::string& value) {
+    return m_client.append(key, value).get();
+  }
+  reply auth(const std::string& password) {
+    return m_client.auth(password).get();
+  }
+  reply bgrewriteaof() {
+    return m_client.bgrewriteaof().get();
+  }
+  reply bgsave() {
+    return m_client.bgsave().get();
+  }
+  reply bitcount(const std::string& key) {
+    return m_client.bitcount(key).get();
+  }
+  reply bitcount(const std::string& key, int start, int end) {
+    return m_client.bitcount(key, start, end).get();
+  }
+  // reply bitfield(const std::string& key) key [get type offset] [set type offset value] [incrby type offset increment] [overflow wrap|sat|fail]
+  reply bitop(const std::string& operation, const std::string& destkey, const std::vector<std::string>& keys) {
+    return m_client.bitop(operation, destkey, keys).get();
+  }
+  reply bitpos(const std::string& key, int bit) {
+    return m_client.bitpos(key, bit).get();
+  }
+  reply bitpos(const std::string& key, int bit, int start) {
+    return m_client.bitpos(key, bit, start).get();
+  }
+  reply bitpos(const std::string& key, int bit, int start, int end) {
+    return m_client.bitpos(key, bit, start, end).get();
+  }
+  reply blpop(const std::vector<std::string>& keys, int timeout) {
+    return m_client.blpop(keys, timeout).get();
+  }
+  reply brpop(const std::vector<std::string>& keys, int timeout) {
+    return m_client.brpop(keys, timeout).get();
+  }
+  reply brpoplpush(const std::string& src, const std::string& dst, int timeout) {
+    return m_client.brpoplpush(src, dst, timeout).get();
+  }
+  // reply client_kill() [ip:port] [id client-id] [type normal|master|slave|pubsub] [addr ip:port] [skipme yes/no]
+  reply client_list() {
+    return m_client.client_list().get();
+  }
+  reply client_getname() {
+    return m_client.client_getname().get();
+  }
+  reply client_pause(int timeout) {
+    return m_client.client_pause(timeout).get();
+  }
+  reply client_reply(const std::string& mode) {
+    return m_client.client_reply(mode).get();
+  }
+  reply client_setname(const std::string& name) {
+    return m_client.client_setname(name).get();
+  }
+  reply cluster_addslots(const std::vector<std::string>& slots) {
+    return m_client.cluster_addslots(slots).get();
+  }
+  reply cluster_count_failure_reports(const std::string& node_id) {
+    return m_client.cluster_count_failure_reports(node_id).get();
+  }
+  reply cluster_countkeysinslot(const std::string& slot) {
+    return m_client.cluster_countkeysinslot(slot).get();
+  }
+  reply cluster_delslots(const std::vector<std::string>& slots) {
+    return m_client.cluster_delslots(slots).get();
+  }
+  reply cluster_failover() {
+    return m_client.cluster_failover().get();
+  }
+  reply cluster_failover(const std::string& mode) {
+    return m_client.cluster_failover(mode).get();
+  }
+  reply cluster_forget(const std::string& node_id) {
+    return m_client.cluster_forget(node_id).get();
+  }
+  reply cluster_getkeysinslot(const std::string& slot, int count) {
+    return m_client.cluster_getkeysinslot(slot, count).get();
+  }
+  reply cluster_info() {
+    return m_client.cluster_info().get();
+  }
+  reply cluster_keyslot(const std::string& key) {
+    return m_client.cluster_keyslot(key).get();
+  }
+  reply cluster_meet(const std::string& ip, int port) {
+    return m_client.cluster_meet(ip, port).get();
+  }
+  reply cluster_nodes() {
+    return m_client.cluster_nodes().get();
+  }
+  reply cluster_replicate(const std::string& node_id) {
+    return m_client.cluster_replicate(node_id).get();
+  }
+  reply cluster_reset(const std::string& mode = "soft") {
+    return m_client.cluster_reset(mode).get();
+  }
+  reply cluster_saveconfig() {
+    return m_client.cluster_saveconfig().get();
+  }
+  reply cluster_set_config_epoch(const std::string& epoch) {
+    return m_client.cluster_set_config_epoch(epoch).get();
+  }
+  reply cluster_setslot(const std::string& slot, const std::string& mode) {
+    return m_client.cluster_setslot(slot, mode).get();
+  }
+  reply cluster_setslot(const std::string& slot, const std::string& mode, const std::string& node_id) {
+    return m_client.cluster_setslot(slot, mode, node_id).get();
+  }
+  reply cluster_slaves(const std::string& node_id) {
+    return m_client.cluster_slaves(node_id).get();
+  }
+  reply cluster_slots() {
+    return m_client.cluster_slots().get();
+  }
+  reply command() {
+    return m_client.command().get();
+  }
+  reply command_count() {
+    return m_client.command_count().get();
+  }
+  reply command_getkeys() {
+    return m_client.command_getkeys().get();
+  }
+  reply command_info(const std::vector<std::string>& command_name) {
+    return m_client.command_info(command_name).get();
+  }
+  reply config_get(const std::string& param) {
+    return m_client.config_get(param).get();
+  }
+  reply config_rewrite() {
+    return m_client.config_rewrite().get();
+  }
+  reply config_set(const std::string& param, const std::string& val) {
+    return m_client.config_set(param, val).get();
+  }
+  reply config_resetstat() {
+    return m_client.config_resetstat().get();
+  }
+  reply dbsize() {
+    return m_client.dbsize().get();
+  }
+  reply debug_object(const std::string& key) {
+    return m_client.debug_object(key).get();
+  }
+  reply debug_segfault() {
+    return m_client.debug_segfault().get();
+  }
+  reply decr(const std::string& key) {
+    return m_client.decr(key).get();
+  }
+  reply decrby(const std::string& key, int val) {
+    return m_client.decrby(key, val).get();
+  }
+  reply del(const std::vector<std::string>& key) {
+    return m_client.del(key).get();
+  }
+  reply discard() {
+    return m_client.discard().get();
+  }
+  reply dump(const std::string& key) {
+    return m_client.dump(key).get();
+  }
+  reply echo(const std::string& msg) {
+    return m_client.echo(msg).get();
+  }
+  reply eval(const std::string& script, int numkeys, const std::vector<std::string>& keys, const std::vector<std::string>& args) {
+    return m_client.eval(script, numkeys, keys, args).get();
+  }
+  reply evalsha(const std::string& sha1, int numkeys, const std::vector<std::string>& keys, const std::vector<std::string>& args) {
+    return m_client.evalsha(sha1, numkeys, keys, args).get();
+  }
+  reply exec() {
+    return m_client.exec().get();
+  }
+  reply exists(const std::vector<std::string>& keys) {
+    return m_client.exists(keys).get();
+  }
+  reply expire(const std::string& key, int seconds) {
+    return m_client.expire(key, seconds).get();
+  }
+  reply expireat(const std::string& key, int timestamp) {
+    return m_client.expireat(key, timestamp).get();
+  }
+  reply flushall() {
+    return m_client.flushall().get();
+  }
+  reply flushdb() {
+    return m_client.flushdb().get();
+  }
+  reply geoadd(const std::string& key, const std::vector<std::tuple<std::string, std::string, std::string>>& long_lat_memb) {
+    return m_client.geoadd(key, long_lat_memb).get();
+  }
+  reply geohash(const std::string& key, const std::vector<std::string>& members) {
+    return m_client.geohash(key, members).get();
+  }
+  reply geopos(const std::string& key, const std::vector<std::string>& members) {
+    return m_client.geopos(key, members).get();
+  }
+  reply geodist(const std::string& key, const std::string& member_1, const std::string& member_2, const std::string& unit = "m") {
+    return m_client.geodist(key, member_1, member_2, unit).get();
+  }
+  // reply georadius() key longitude latitude radius m|km|ft|mi [withcoord] [withdist] [withhash] [count count] [asc|desc] [store key] [storedist key]
+  // reply georadiusbymember() key member radius m|km|ft|mi [withcoord] [withdist] [withhash] [count count] [asc|desc] [store key] [storedist key]
+  reply get(const std::string& key) {
+    return m_client.get(key).get();
+  }
+  reply getbit(const std::string& key, int offset) {
+    return m_client.getbit(key, offset).get();
+  }
+  reply getrange(const std::string& key, int start, int end) {
+    return m_client.getrange(key, start, end).get();
+  }
+  reply getset(const std::string& key, const std::string& val) {
+    return m_client.getset(key, val).get();
+  }
+  reply hdel(const std::string& key, const std::vector<std::string>& fields) {
+    return m_client.hdel(key, fields).get();
+  }
+  reply hexists(const std::string& key, const std::string& field) {
+    return m_client.hexists(key, field).get();
+  }
+  reply hget(const std::string& key, const std::string& field) {
+    return m_client.hget(key, field).get();
+  }
+  reply hgetall(const std::string& key) {
+    return m_client.hgetall(key).get();
+  }
+  reply hincrby(const std::string& key, const std::string& field, int incr) {
+    return m_client.hincrby(key, field, incr).get();
+  }
+  reply hincrbyfloat(const std::string& key, const std::string& field, float incr) {
+    return m_client.hincrbyfloat(key, field, incr).get();
+  }
+  reply hkeys(const std::string& key) {
+    return m_client.hkeys(key).get();
+  }
+  reply hlen(const std::string& key) {
+    return m_client.hlen(key).get();
+  }
+  reply hmget(const std::string& key, const std::vector<std::string>& fields) {
+    return m_client.hmget(key, fields).get();
+  }
+  reply hmset(const std::string& key, const std::vector<std::pair<std::string, std::string>>& field_val) {
+    return m_client.hmset(key, field_val).get();
+  }
+  reply hset(const std::string& key, const std::string& field, const std::string& value) {
+    return m_client.hset(key, field, value).get();
+  }
+  reply hsetnx(const std::string& key, const std::string& field, const std::string& value) {
+    return m_client.hsetnx(key, field, value).get();
+  }
+  reply hstrlen(const std::string& key, const std::string& field) {
+    return m_client.hstrlen(key, field).get();
+  }
+  reply hvals(const std::string& key) {
+    return m_client.hvals(key).get();
+  }
+  reply incr(const std::string& key) {
+    return m_client.incr(key).get();
+  }
+  reply incrby(const std::string& key, int incr) {
+    return m_client.incrby(key, incr).get();
+  }
+  reply incrbyfloat(const std::string& key, float incr) {
+    return m_client.incrbyfloat(key, incr).get();
+  }
+  reply info(const std::string& section = "default") {
+    return m_client.info(section).get();
+  }
+  reply keys(const std::string& pattern) {
+    return m_client.keys(pattern).get();
+  }
+  reply lastsave() {
+    return m_client.lastsave().get();
+  }
+  reply lindex(const std::string& key, int index) {
+    return m_client.lindex(key, index).get();
+  }
+  reply linsert(const std::string& key, const std::string& before_after, const std::string& pivot, const std::string& value) {
+    return m_client.linsert(key, before_after, pivot, value).get();
+  }
+  reply llen(const std::string& key) {
+    return m_client.llen(key).get();
+  }
+  reply lpop(const std::string& key) {
+    return m_client.lpop(key).get();
+  }
+  reply lpush(const std::string& key, const std::vector<std::string>& values) {
+    return m_client.lpush(key, values).get();
+  }
+  reply lpushx(const std::string& key, const std::string& value) {
+    return m_client.lpushx(key, value).get();
+  }
+  reply lrange(const std::string& key, int start, int stop) {
+    return m_client.lrange(key, start, stop).get();
+  }
+  reply lrem(const std::string& key, int count, const std::string& value) {
+    return m_client.lrem(key, count, value).get();
+  }
+  reply lset(const std::string& key, int index, const std::string& value) {
+    return m_client.lset(key, index, value).get();
+  }
+  reply ltrim(const std::string& key, int start, int stop) {
+    return m_client.ltrim(key, start, stop).get();
+  }
+  reply mget(const std::vector<std::string>& keys) {
+    return m_client.mget(keys).get();
+  }
+  reply migrate(const std::string& host, int port, const std::string& key, const std::string& dest_db, int timeout, bool copy = false, bool replace = false, const std::vector<std::string>& keys = {}) {
+    return m_client.migrate(host, port, key, dest_db, timeout, copy, replace, keys).get();
+  }
+  reply monitor() {
+    return m_client.monitor().get();
+  }
+  reply move(const std::string& key, const std::string& db) {
+    return m_client.move(key, db).get();
+  }
+  reply mset(const std::vector<std::pair<std::string, std::string>>& key_vals) {
+    return m_client.mset(key_vals).get();
+  }
+  reply msetnx(const std::vector<std::pair<std::string, std::string>>& key_vals) {
+    return m_client.msetnx(key_vals).get();
+  }
+  reply multi() {
+    return m_client.multi().get();
+  }
+  reply object(const std::string& subcommand, const std::vector<std::string>& args) {
+    return m_client.object(subcommand, args).get();
+  }
+  reply persist(const std::string& key) {
+    return m_client.persist(key).get();
+  }
+  reply pexpire(const std::string& key, int milliseconds) {
+    return m_client.pexpire(key, milliseconds).get();
+  }
+  reply pexpireat(const std::string& key, int milliseconds_timestamp) {
+    return m_client.pexpireat(key, milliseconds_timestamp).get();
+  }
+  reply pfadd(const std::string& key, const std::vector<std::string>& elements) {
+    return m_client.pfadd(key, elements).get();
+  }
+  reply pfcount(const std::vector<std::string>& keys) {
+    return m_client.pfcount(keys).get();
+  }
+  reply pfmerge(const std::string& destkey, const std::vector<std::string>& sourcekeys) {
+    return m_client.pfmerge(destkey, sourcekeys).get();
+  }
+  reply ping() {
+    return m_client.ping().get();
+  }
+  reply ping(const std::string& message) {
+    return m_client.ping(message).get();
+  }
+  reply psetex(const std::string& key, int milliseconds, const std::string& val) {
+    return m_client.psetex(key, milliseconds, val).get();
+  }
+  reply publish(const std::string& channel, const std::string& message) {
+    return m_client.publish(channel, message).get();
+  }
+  reply pubsub(const std::string& subcommand, const std::vector<std::string>& args) {
+    return m_client.pubsub(subcommand, args).get();
+  }
+  reply pttl(const std::string& key) {
+    return m_client.pttl(key).get();
+  }
+  reply quit() {
+    return m_client.quit().get();
+  }
+  reply randomkey() {
+    return m_client.randomkey().get();
+  }
+  reply readonly() {
+    return m_client.readonly().get();
+  }
+  reply readwrite() {
+    return m_client.readwrite().get();
+  }
+  reply rename(const std::string& key, const std::string& newkey) {
+    return m_client.rename(key, newkey).get();
+  }
+  reply renamenx(const std::string& key, const std::string& newkey) {
+    return m_client.renamenx(key, newkey).get();
+  }
+  reply restore(const std::string& key, int ttl, const std::string& serialized_value) {
+    return m_client.restore(key, ttl, serialized_value).get();
+  }
+  reply restore(const std::string& key, int ttl, const std::string& serialized_value, const std::string& replace) {
+    return m_client.restore(key, ttl, serialized_value, replace).get();
+  }
+  reply role() {
+    return m_client.role().get();
+  }
+  reply rpop(const std::string& key) {
+    return m_client.rpop(key).get();
+  }
+  reply rpoplpush(const std::string& src, const std::string& dest) {
+    return m_client.rpoplpush(src, dest).get();
+  }
+  reply rpush(const std::string& key, const std::vector<std::string>& values) {
+    return m_client.rpush(key, values).get();
+  }
+  reply rpushx(const std::string& key, const std::string& value) {
+    return m_client.rpushx(key, value).get();
+  }
+  reply sadd(const std::string& key, const std::vector<std::string>& members) {
+    return m_client.sadd(key, members).get();
+  }
+  reply save() {
+    return m_client.save().get();
+  }
+  reply scard(const std::string& key) {
+    return m_client.scard(key).get();
+  }
+  reply script_debug(const std::string& mode) {
+    return m_client.script_debug(mode).get();
+  }
+  reply script_exists(const std::vector<std::string>& scripts) {
+    return m_client.script_exists(scripts).get();
+  }
+  reply script_flush() {
+    return m_client.script_flush().get();
+  }
+  reply script_kill() {
+    return m_client.script_kill().get();
+  }
+  reply script_load(const std::string& script) {
+    return m_client.script_load(script).get();
+  }
+  reply sdiff(const std::vector<std::string>& keys)  {
+    return m_client.sdiff(keys).get();
+  }
+  reply sdiffstore(const std::string& dest, const std::vector<std::string>& keys)  {
+    return m_client.sdiffstore(dest, keys).get();
+  }
+  reply select(int index)  {
+    return m_client.select(index).get();
+  }
+  reply set(const std::string& key, const std::string& value)  {
+    return m_client.set(key, value).get();
+  }
+  reply set_advanced(const std::string& key, const std::string& value, bool ex = false, int ex_sec = 0, bool px = false, int px_milli = 0, bool nx = false, bool xx = false)  {
+    return m_client.set_advanced(key, value, ex, ex_sec, px, px_milli, nx, xx).get();
+  }
+  reply setbit(const std::string& key, int offset, const std::string& value)  {
+    return m_client.setbit(key, offset, value).get();
+  }
+  reply setex(const std::string& key, int seconds, const std::string& value)  {
+    return m_client.setex(key, seconds, value).get();
+  }
+  reply setnx(const std::string& key, const std::string& value)  {
+    return m_client.setnx(key, value).get();
+  }
+  reply setrange(const std::string& key, int offset, const std::string& value)  {
+    return m_client.setrange(key, offset, value).get();
+  }
+  reply shutdown() {
+    return m_client.shutdown().get();
+  }
+  reply shutdown(const std::string& save) {
+    return m_client.shutdown(save).get();
+  }
+  reply sinter(const std::vector<std::string>& keys) {
+    return m_client.sinter(keys).get();
+  }
+  reply sinterstore(const std::string& dest, const std::vector<std::string>& keys) {
+    return m_client.sinterstore(dest, keys).get();
+  }
+  reply sismember(const std::string& key, const std::string& member) {
+    return m_client.sismember(key, member).get();
+  }
+  reply slaveof(const std::string& host, int port) {
+    return m_client.slaveof(host, port).get();
+  }
+  reply slowlog(const std::string& subcommand) {
+    return m_client.slowlog(subcommand).get();
+  }
+  reply slowlog(const std::string& subcommand, const std::string& argument) {
+    return m_client.slowlog(subcommand, argument).get();
+  }
+  reply smembers(const std::string& key) {
+    return m_client.smembers(key).get();
+  }
+  reply smove(const std::string& src, const std::string& dest, const std::string& member) {
+    return m_client.smove(src, dest, member).get();
+  }
+  // reply sort() key [by pattern] [limit offset count] [get pattern [get pattern ...]] [asc|desc] [alpha] [store dest]
+  reply spop(const std::string& key) {
+    return m_client.spop(key).get();
+  }
+  reply spop(const std::string& key, int count) {
+    return m_client.spop(key, count).get();
+  }
+  reply srandmember(const std::string& key) {
+    return m_client.srandmember(key).get();
+  }
+  reply srandmember(const std::string& key, int count) {
+    return m_client.srandmember(key, count).get();
+  }
+  reply srem(const std::string& key, const std::vector<std::string>& members) {
+    return m_client.srem(key, members).get();
+  }
+  reply strlen(const std::string& key) {
+    return m_client.strlen(key).get();
+  }
+  reply sunion(const std::vector<std::string>& keys) {
+    return m_client.sunion(keys).get();
+  }
+  reply sunionstore(const std::string& dest, const std::vector<std::string>& keys) {
+    return m_client.sunionstore(dest, keys).get();
+  }
+  reply sync() {
+    return m_client.sync().get();
+  }
+  reply time() {
+    return m_client.time().get();
+  }
+  reply ttl(const std::string& key) {
+    return m_client.ttl(key).get();
+  }
+  reply type(const std::string& key) {
+    return m_client.type(key).get();
+  }
+  reply unwatch() {
+    return m_client.unwatch().get();
+  }
+  reply wait(int numslaves, int timeout) {
+    return m_client.wait(numslaves, timeout).get();
+  }
+  reply watch(const std::vector<std::string>& keys) {
+    return m_client.watch(keys).get();
+  }
+  // reply zadd() key [nx|xx] [ch] [incr] score member [score member ...]
+  reply zcard(const std::string& key) {
+    return m_client.zcard(key).get();
+  }
+  reply zcount(const std::string& key, int min, int max) {
+    return m_client.zcount(key, min, max).get();
+  }
+  reply zincrby(const std::string& key, int incr, const std::string& member) {
+    return m_client.zincrby(key, incr, member).get();
+  }
+  // reply zinterstore() dest numkeys key [key ...] [weights weight [weight ...]] [aggregate sum|min|max]
+  reply zlexcount(const std::string& key, int min, int max) {
+    return m_client.zlexcount(key, min, max).get();
+  }
+  reply zrange(const std::string& key, int start, int stop, bool withscores = false) {
+    return m_client.zrange(key, start, stop, withscores).get();
+  }
+  // reply zrangebylex() key min max [limit offset count]
+  // reply zrevrangebylex() key max min [limit offset count]
+  // reply zrangebyscore() key min max [withscores] [limit offset count]
+  reply zrank(const std::string& key, const std::string& member) {
+    return m_client.zrank(key, member).get();
+  }
+  reply zrem(const std::string& key, const std::vector<std::string>& members) {
+    return m_client.zrem(key, members).get();
+  }
+  reply zremrangebylex(const std::string& key, int min, int max) {
+    return m_client.zremrangebylex(key, min, max).get();
+  }
+  reply zremrangebyrank(const std::string& key, int start, int stop) {
+    return m_client.zremrangebyrank(key, start, stop).get();
+  }
+  reply zremrangebyscore(const std::string& key, int min, int max) {
+    return m_client.zremrangebyscore(key, min, max).get();
+  }
+  reply zrevrange(const std::string& key, int start, int stop, bool withscores = false) {
+    return m_client.zrevrange(key, start, stop, withscores).get();
+  }
+  // reply zrevrangebyscore() key max min [withscores] [limit offset count]
+  reply zrevrank(const std::string& key, const std::string& member) {
+    return m_client.zrevrank(key, member).get();
+  }
+  reply zscore(const std::string& key, const std::string& member) {
+    return m_client.zscore(key, member).get();
+  }
+  // reply zunionstore() dest numkeys key [key ...] [weights weight [weight ...]] [aggregate sum|min|max]
+  // reply scan() cursor [match pattern] [count count]
+  // reply sscan() key cursor [match pattern] [count count]
+  // reply hscan() key cursor [match pattern] [count count]
+  // reply zscan() key cursor [match pattern] [count count]
+
+private:
+  future_client m_client;
+};
+
+} //! cpp_redis
+

--- a/sources/future_client.cpp
+++ b/sources/future_client.cpp
@@ -1,0 +1,18 @@
+#include <cpp_redis/future_client.hpp>
+#include <cpp_redis/redis_error.hpp>
+
+namespace cpp_redis {
+
+future_client::future_client(const std::shared_ptr<network::io_service>& io_service)
+: m_client(io_service)
+{
+  __CPP_REDIS_LOG(debug, "cpp_redis::future_client created");
+}
+
+future_client::~future_client(void) {
+  __CPP_REDIS_LOG(debug, "cpp_redis::future_client destroyed");
+}
+
+
+} //! cpp_redis
+

--- a/sources/sync_client.cpp
+++ b/sources/sync_client.cpp
@@ -1,0 +1,18 @@
+#include <cpp_redis/sync_client.hpp>
+#include <cpp_redis/redis_error.hpp>
+
+namespace cpp_redis {
+
+sync_client::sync_client(const std::shared_ptr<network::io_service>& io_service)
+: m_client(io_service)
+{
+  __CPP_REDIS_LOG(debug, "cpp_redis::sync_client created");
+}
+
+sync_client::~sync_client(void) {
+  __CPP_REDIS_LOG(debug, "cpp_redis::sync_client destroyed");
+}
+
+
+} //! cpp_redis
+


### PR DESCRIPTION
This adds two new clients. The "future_client" presents an asynchronous interface using C++11 std::future types, and the "sync_client" presents a synchronous interface. Both sit atop the original "redis_client" and are fully backward compatible.