### PR TITLE
Issue #37

### DIFF
--- a/examples/redis_subscriber.cpp
+++ b/examples/redis_subscriber.cpp
@@ -29,7 +29,7 @@
 #include <Winsock2.h>
 #endif /* _WIN32 */
 
-volatile std::atomic_bool should_exit(false);
+volatile std::atomic_bool should_exit = ATOMIC_VAR_INIT(false);
 
 void
 sigint_handler(int) {

--- a/includes/cpp_redis/redis_client.hpp
+++ b/includes/cpp_redis/redis_client.hpp
@@ -308,7 +308,7 @@ private:
   std::mutex m_callbacks_mutex;
   std::mutex m_send_mutex;
   std::condition_variable m_sync_condvar;
-  std::atomic_uint m_callbacks_running;
+  std::atomic_uint m_callbacks_running = ATOMIC_VAR_INIT(0);
 };
 
 } //! cpp_redis

--- a/includes/cpp_redis/redis_error.hpp
+++ b/includes/cpp_redis/redis_error.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <stdexcept>
+#include <string>
 
 namespace cpp_redis {
 
@@ -32,13 +33,11 @@ public:
   using std::runtime_error::what;
 
   explicit redis_error(const std::string& _Message)
-	  : std::runtime_error(_Message.c_str())
-  {	// construct from message string
+  : std::runtime_error(_Message.c_str()) { // construct from message string
   }
 
-  explicit redis_error(const char *_Message)
-	  : std::runtime_error(_Message)
-  {	// construct from message string
+  explicit redis_error(const char* _Message)
+  : std::runtime_error(_Message) { // construct from message string
   }
 };
 

--- a/includes/cpp_redis/redis_error.hpp
+++ b/includes/cpp_redis/redis_error.hpp
@@ -30,6 +30,16 @@ class redis_error : public std::runtime_error {
 public:
   using std::runtime_error::runtime_error;
   using std::runtime_error::what;
+
+  explicit redis_error(const std::string& _Message)
+	  : std::runtime_error(_Message.c_str())
+  {	// construct from message string
+  }
+
+  explicit redis_error(const char *_Message)
+	  : std::runtime_error(_Message)
+  {	// construct from message string
+  }
 };
 
 } //! cpp_redis

--- a/sources/redis_client.cpp
+++ b/sources/redis_client.cpp
@@ -26,7 +26,7 @@
 namespace cpp_redis {
 
 redis_client::redis_client(void)
-: m_callbacks_running(0) {
+: m_callbacks_running(ATOMIC_VAR_INIT(0)) {
   __CPP_REDIS_LOG(debug, "cpp_redis::redis_client created");
 }
 

--- a/sources/redis_client.cpp
+++ b/sources/redis_client.cpp
@@ -25,8 +25,7 @@
 
 namespace cpp_redis {
 
-redis_client::redis_client(void)
-: m_callbacks_running(ATOMIC_VAR_INIT(0)) {
+redis_client::redis_client(void) {
   __CPP_REDIS_LOG(debug, "cpp_redis::redis_client created");
 }
 

--- a/tests/sources/spec/redis_client_spec.cpp
+++ b/tests/sources/spec/redis_client_spec.cpp
@@ -121,7 +121,7 @@ TEST(RedisClient, SyncCommitTimeout) {
   cpp_redis::redis_client client;
 
   client.connect();
-  volatile std::atomic_bool callback_exit(false);
+  volatile std::atomic_bool callback_exit = ATOMIC_VAR_INIT(false);
   client.send({"GET", "HELLO"}, [&](cpp_redis::reply&) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     callback_exit = true;
@@ -136,7 +136,7 @@ TEST(RedisClient, SyncCommitNoTimeout) {
   cpp_redis::redis_client client;
 
   client.connect();
-  std::atomic_bool callback_exit(false);
+  std::atomic_bool callback_exit = ATOMIC_VAR_INIT(false);
   client.send({"GET", "HELLO"}, [&](cpp_redis::reply&) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     callback_exit = true;
@@ -163,7 +163,7 @@ TEST(RedisClient, SendConnectedSyncCommitConnected) {
 
   client.connect();
 
-  std::atomic_bool callback_run(false);
+  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
   client.send({"GET", "HELLO"}, [&](cpp_redis::reply&) {
     callback_run = true;
   });
@@ -175,7 +175,7 @@ TEST(RedisClient, SendConnectedSyncCommitConnected) {
 TEST(RedisClient, SendNotConnectedSyncCommitConnected) {
   cpp_redis::redis_client client;
 
-  std::atomic_bool callback_run(false);
+  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
   client.send({"GET", "HELLO"}, [&](cpp_redis::reply&) {
     callback_run = true;
   });
@@ -188,7 +188,7 @@ TEST(RedisClient, SendNotConnectedSyncCommitConnected) {
 TEST(RedisClient, SendNotConnectedSyncCommitNotConnectedSyncCommitConnected) {
   cpp_redis::redis_client client;
 
-  std::atomic_bool callback_run(false);
+  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
   client.send({"GET", "HELLO"}, [&](cpp_redis::reply&) {
     callback_run = true;
   });
@@ -259,7 +259,7 @@ TEST(RedisClient, DisconnectionHandlerWithQuit) {
   cpp_redis::redis_client client;
   std::condition_variable cv;
 
-  std::atomic_bool disconnection_handler_called(false);
+  std::atomic_bool disconnection_handler_called = ATOMIC_VAR_INIT(false);
   client.connect("127.0.0.1", 6379, [&](cpp_redis::redis_client&) {
     disconnection_handler_called = true;
     cv.notify_all();
@@ -279,7 +279,7 @@ TEST(RedisClient, DisconnectionHandlerWithoutQuit) {
   cpp_redis::redis_client client;
   std::condition_variable cv;
 
-  std::atomic_bool disconnection_handler_called(false);
+  std::atomic_bool disconnection_handler_called = ATOMIC_VAR_INIT(false);
   client.connect("127.0.0.1", 6379, [&](cpp_redis::redis_client&) {
     disconnection_handler_called = true;
     cv.notify_all();

--- a/tests/sources/spec/redis_subscriber_spec.cpp
+++ b/tests/sources/spec/redis_subscriber_spec.cpp
@@ -152,7 +152,7 @@ TEST(RedisSubscriber, SubConnectedCommitConnected) {
   sub.connect();
   client.connect();
 
-  std::atomic_bool callback_run(false);
+  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
   sub.subscribe("/chan",
     [&](const std::string&, const std::string&) {
       callback_run = true;
@@ -179,7 +179,7 @@ TEST(RedisSubscriber, SubNotConnectedCommitConnected) {
 
   client.connect();
 
-  std::atomic_bool callback_run(false);
+  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
   sub.subscribe("/chan",
     [&](const std::string&, const std::string&) {
       callback_run = true;
@@ -206,7 +206,7 @@ TEST(RedisSubscriber, SubNotConnectedCommitNotConnectedCommitConnected) {
 
   client.connect();
 
-  std::atomic_bool callback_run(false);
+  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
   sub.subscribe("/chan",
     [&](const std::string&, const std::string&) {
       callback_run = true;
@@ -233,7 +233,7 @@ TEST(RedisSubscriber, SubscribeSomethingPublished) {
   sub.connect();
   client.connect();
 
-  std::atomic_bool callback_run(false);
+  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
   sub.subscribe("/chan",
     [&](const std::string& channel, const std::string& message) {
       EXPECT_TRUE(channel == "/chan");
@@ -263,7 +263,7 @@ TEST(RedisSubscriber, SubscribeMultiplePublished) {
   sub.connect();
   client.connect();
 
-  std::atomic_int number_times_called(0);
+  std::atomic_int number_times_called = ATOMIC_VAR_INIT(0);
   sub.subscribe("/chan",
     [&](const std::string& channel, const std::string& message) {
       EXPECT_TRUE(channel == "/chan");
@@ -296,7 +296,7 @@ TEST(RedisSubscriber, SubscribeNothingPublished) {
   sub.connect();
   client.connect();
 
-  std::atomic_bool callback_run(false);
+  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
   sub.subscribe("/chan",
     [&](const std::string&, const std::string&) {
       callback_run = true;
@@ -329,8 +329,8 @@ TEST(RedisSubscriber, MultipleSubscribeSomethingPublished) {
     }
   };
 
-  std::atomic_bool callback_1_run(false);
-  std::atomic_bool callback_2_run(false);
+  std::atomic_bool callback_1_run = ATOMIC_VAR_INIT(false);
+  std::atomic_bool callback_2_run = ATOMIC_VAR_INIT(false);
   sub.subscribe("/chan_1",
     [&](const std::string& channel, const std::string& message) {
       EXPECT_TRUE(channel == "/chan_1");
@@ -370,7 +370,7 @@ TEST(RedisSubscriber, PSubscribeSomethingPublished) {
   sub.connect();
   client.connect();
 
-  std::atomic_bool callback_run(false);
+  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
   sub.psubscribe("/chan/*",
     [&](const std::string& channel, const std::string& message) {
       EXPECT_TRUE(channel == "/chan/hello");
@@ -400,7 +400,7 @@ TEST(RedisSubscriber, PSubscribeMultiplePublished) {
   sub.connect();
   client.connect();
 
-  std::atomic_int number_times_called(0);
+  std::atomic_int number_times_called = ATOMIC_VAR_INIT(0);
   sub.psubscribe("/chan/*",
     [&](const std::string& channel, const std::string& message) {
       ++number_times_called;
@@ -440,7 +440,7 @@ TEST(RedisSubscriber, PSubscribeNothingPublished) {
   sub.connect();
   client.connect();
 
-  std::atomic_bool callback_run(false);
+  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
   sub.psubscribe("/chan/*",
     [&](const std::string&, const std::string&) {
       callback_run = true;
@@ -473,8 +473,8 @@ TEST(RedisSubscriber, MultiplePSubscribeSomethingPublished) {
     }
   };
 
-  std::atomic_bool callback_1_run(false);
-  std::atomic_bool callback_2_run(false);
+  std::atomic_bool callback_1_run = ATOMIC_VAR_INIT(false);
+  std::atomic_bool callback_2_run = ATOMIC_VAR_INIT(false);
   sub.psubscribe("/chan/*",
     [&](const std::string& channel, const std::string& message) {
       EXPECT_TRUE(channel == "/chan/1");
@@ -522,8 +522,8 @@ TEST(RedisSubscriber, Unsubscribe) {
     }
   };
 
-  std::atomic_bool callback_1_run(false);
-  std::atomic_bool callback_2_run(false);
+  std::atomic_bool callback_1_run = ATOMIC_VAR_INIT(false);
+  std::atomic_bool callback_2_run = ATOMIC_VAR_INIT(false);
   sub.subscribe("/chan_1",
     [&](const std::string&, const std::string&) {
       callback_1_run = true;
@@ -563,8 +563,8 @@ TEST(RedisSubscriber, PUnsubscribe) {
     }
   };
 
-  std::atomic_bool callback_1_run(false);
-  std::atomic_bool callback_2_run(false);
+  std::atomic_bool callback_1_run = ATOMIC_VAR_INIT(false);
+  std::atomic_bool callback_2_run = ATOMIC_VAR_INIT(false);
   sub.psubscribe("/chan_1/*",
     [&](const std::string&, const std::string&) {
       callback_1_run = true;


### PR DESCRIPTION
@Cylix and @simpuc please take a look about what was being discussed on issue #37.

I just made a little change on the constructor (explict keyword) and included another constructor.

All tests seems to pass...

PS: To this fix works properly tacopie also needs some fix for the std::atomic issues. Should I do a pull request there too?

```[==========] Running 111 tests from 10 test cases.
[----------] Global test environment set-up.
[----------] 25 tests from RedisClient
[ RUN      ] RedisClient.ValidConnectionDefaultParams
[       OK ] RedisClient.ValidConnectionDefaultParams (35 ms)
[ RUN      ] RedisClient.ValidConnectionDefinedHost
[       OK ] RedisClient.ValidConnectionDefinedHost (1 ms)
[ RUN      ] RedisClient.InvalidConnection
[       OK ] RedisClient.InvalidConnection (12 ms)
[ RUN      ] RedisClient.AlreadyConnected
[       OK ] RedisClient.AlreadyConnected (1 ms)
[ RUN      ] RedisClient.Disconnection
[       OK ] RedisClient.Disconnection (1 ms)
[ RUN      ] RedisClient.DisconnectionNotConnected
[       OK ] RedisClient.DisconnectionNotConnected (0 ms)
[ RUN      ] RedisClient.CommitConnected
[       OK ] RedisClient.CommitConnected (1 ms)
[ RUN      ] RedisClient.CommitNotConnected
[       OK ] RedisClient.CommitNotConnected (1 ms)
[ RUN      ] RedisClient.SyncCommitConnected
[       OK ] RedisClient.SyncCommitConnected (1 ms)
[ RUN      ] RedisClient.SyncCommitNotConnected
[       OK ] RedisClient.SyncCommitNotConnected (1 ms)
[ RUN      ] RedisClient.SyncCommitTimeoutConnected
[       OK ] RedisClient.SyncCommitTimeoutConnected (1 ms)
[ RUN      ] RedisClient.SyncCommitTimeoutNotConnected
[       OK ] RedisClient.SyncCommitTimeoutNotConnected (1 ms)
[ RUN      ] RedisClient.SyncCommitTimeout
[       OK ] RedisClient.SyncCommitTimeout (1001 ms)
[ RUN      ] RedisClient.SyncCommitNoTimeout
[       OK ] RedisClient.SyncCommitNoTimeout (1004 ms)
[ RUN      ] RedisClient.SendConnected
[       OK ] RedisClient.SendConnected (0 ms)
[ RUN      ] RedisClient.SendNotConnected
[       OK ] RedisClient.SendNotConnected (0 ms)
[ RUN      ] RedisClient.SendConnectedSyncCommitConnected
[       OK ] RedisClient.SendConnectedSyncCommitConnected (1 ms)
[ RUN      ] RedisClient.SendNotConnectedSyncCommitConnected
[       OK ] RedisClient.SendNotConnectedSyncCommitConnected (1 ms)
[ RUN      ] RedisClient.SendNotConnectedSyncCommitNotConnectedSyncCommitConnected
[       OK ] RedisClient.SendNotConnectedSyncCommitNotConnectedSyncCommitConnected (1 ms)
[ RUN      ] RedisClient.Send
[       OK ] RedisClient.Send (1 ms)
[ RUN      ] RedisClient.MultipleSend
[       OK ] RedisClient.MultipleSend (1 ms)
[ RUN      ] RedisClient.MultipleSendPipeline
[       OK ] RedisClient.MultipleSendPipeline (1 ms)
[ RUN      ] RedisClient.DisconnectionHandlerWithQuit
[       OK ] RedisClient.DisconnectionHandlerWithQuit (101 ms)
[ RUN      ] RedisClient.DisconnectionHandlerWithoutQuit
[       OK ] RedisClient.DisconnectionHandlerWithoutQuit (2012 ms)
[ RUN      ] RedisClient.ClearBufferOnError
[       OK ] RedisClient.ClearBufferOnError (3 ms)
[----------] 25 tests from RedisClient (4206 ms total)

[----------] 29 tests from RedisSubscriber
[ RUN      ] RedisSubscriber.ValidConnectionDefaultParams
[       OK ] RedisSubscriber.ValidConnectionDefaultParams (1 ms)
[ RUN      ] RedisSubscriber.ValidConnectionDefinedHost
[       OK ] RedisSubscriber.ValidConnectionDefinedHost (1 ms)
[ RUN      ] RedisSubscriber.InvalidConnection
[       OK ] RedisSubscriber.InvalidConnection (1 ms)
[ RUN      ] RedisSubscriber.AlreadyConnected
[       OK ] RedisSubscriber.AlreadyConnected (1 ms)
[ RUN      ] RedisSubscriber.Disconnection
[       OK ] RedisSubscriber.Disconnection (0 ms)
[ RUN      ] RedisSubscriber.DisconnectionNotConnected
[       OK ] RedisSubscriber.DisconnectionNotConnected (0 ms)
[ RUN      ] RedisSubscriber.CommitConnected
[       OK ] RedisSubscriber.CommitConnected (0 ms)
[ RUN      ] RedisSubscriber.CommitNotConnected
[       OK ] RedisSubscriber.CommitNotConnected (1 ms)
[ RUN      ] RedisSubscriber.SubscribeConnected
[       OK ] RedisSubscriber.SubscribeConnected (1 ms)
[ RUN      ] RedisSubscriber.PSubscribeConnected
[       OK ] RedisSubscriber.PSubscribeConnected (1 ms)
[ RUN      ] RedisSubscriber.UnsubscribeConnected
[       OK ] RedisSubscriber.UnsubscribeConnected (1 ms)
[ RUN      ] RedisSubscriber.PUnsubscribeConnected
[       OK ] RedisSubscriber.PUnsubscribeConnected (0 ms)
[ RUN      ] RedisSubscriber.SubscribeNotConnected
[       OK ] RedisSubscriber.SubscribeNotConnected (0 ms)
[ RUN      ] RedisSubscriber.PSubscribeNotConnected
[       OK ] RedisSubscriber.PSubscribeNotConnected (0 ms)
[ RUN      ] RedisSubscriber.UnsubscribeNotConnected
[       OK ] RedisSubscriber.UnsubscribeNotConnected (0 ms)
[ RUN      ] RedisSubscriber.PUnsubscribeNotConnected
[       OK ] RedisSubscriber.PUnsubscribeNotConnected (0 ms)
[ RUN      ] RedisSubscriber.SubConnectedCommitConnected
[       OK ] RedisSubscriber.SubConnectedCommitConnected (3 ms)
[ RUN      ] RedisSubscriber.SubNotConnectedCommitConnected
[       OK ] RedisSubscriber.SubNotConnectedCommitConnected (2 ms)
[ RUN      ] RedisSubscriber.SubNotConnectedCommitNotConnectedCommitConnected
[       OK ] RedisSubscriber.SubNotConnectedCommitNotConnectedCommitConnected (2003 ms)
[ RUN      ] RedisSubscriber.SubscribeSomethingPublished
[       OK ] RedisSubscriber.SubscribeSomethingPublished (2 ms)
[ RUN      ] RedisSubscriber.SubscribeMultiplePublished
[       OK ] RedisSubscriber.SubscribeMultiplePublished (2 ms)
[ RUN      ] RedisSubscriber.SubscribeNothingPublished
[       OK ] RedisSubscriber.SubscribeNothingPublished (2001 ms)
[ RUN      ] RedisSubscriber.MultipleSubscribeSomethingPublished
[       OK ] RedisSubscriber.MultipleSubscribeSomethingPublished (3 ms)
[ RUN      ] RedisSubscriber.PSubscribeSomethingPublished
[       OK ] RedisSubscriber.PSubscribeSomethingPublished (2 ms)
[ RUN      ] RedisSubscriber.PSubscribeMultiplePublished
[       OK ] RedisSubscriber.PSubscribeMultiplePublished (3 ms)
[ RUN      ] RedisSubscriber.PSubscribeNothingPublished
[       OK ] RedisSubscriber.PSubscribeNothingPublished (2002 ms)
[ RUN      ] RedisSubscriber.MultiplePSubscribeSomethingPublished
[       OK ] RedisSubscriber.MultiplePSubscribeSomethingPublished (3 ms)
[ RUN      ] RedisSubscriber.Unsubscribe
[       OK ] RedisSubscriber.Unsubscribe (3 ms)
[ RUN      ] RedisSubscriber.PUnsubscribe
[       OK ] RedisSubscriber.PUnsubscribe (2 ms)
[----------] 29 tests from RedisSubscriber (6076 ms total)

[----------] 6 tests from Reply
[ RUN      ] Reply.NullReply
[       OK ] Reply.NullReply (1 ms)
[ RUN      ] Reply.Error
[       OK ] Reply.Error (0 ms)
[ RUN      ] Reply.BulkString
[       OK ] Reply.BulkString (0 ms)
[ RUN      ] Reply.SimpleString
[       OK ] Reply.SimpleString (1 ms)
[ RUN      ] Reply.Integer
[       OK ] Reply.Integer (2 ms)
[ RUN      ] Reply.Array
[       OK ] Reply.Array (1 ms)
[----------] 6 tests from Reply (10 ms total)

[----------] 7 tests from ArrayBuilder
[ RUN      ] ArrayBuilder.WithNoData
[       OK ] ArrayBuilder.WithNoData (0 ms)
[ RUN      ] ArrayBuilder.WithNotEnoughData
[       OK ] ArrayBuilder.WithNotEnoughData (0 ms)
[ RUN      ] ArrayBuilder.WithPartOfEndSequence
[       OK ] ArrayBuilder.WithPartOfEndSequence (0 ms)
[ RUN      ] ArrayBuilder.WithAllInOneTime
[       OK ] ArrayBuilder.WithAllInOneTime (0 ms)
[ RUN      ] ArrayBuilder.WithAllInMultipleTimes
[       OK ] ArrayBuilder.WithAllInMultipleTimes (0 ms)
[ RUN      ] ArrayBuilder.EmptyArray
[       OK ] ArrayBuilder.EmptyArray (0 ms)
[ RUN      ] ArrayBuilder.InvalidSize
[       OK ] ArrayBuilder.InvalidSize (0 ms)
[----------] 7 tests from ArrayBuilder (7 ms total)

[----------] 6 tests from BuildersFactory
[ RUN      ] BuildersFactory.Array
[       OK ] BuildersFactory.Array (0 ms)
[ RUN      ] BuildersFactory.BulkString
[       OK ] BuildersFactory.BulkString (0 ms)
[ RUN      ] BuildersFactory.Error
[       OK ] BuildersFactory.Error (0 ms)
[ RUN      ] BuildersFactory.Integer
[       OK ] BuildersFactory.Integer (0 ms)
[ RUN      ] BuildersFactory.SimpleString
[       OK ] BuildersFactory.SimpleString (0 ms)
[ RUN      ] BuildersFactory.Unknown
[       OK ] BuildersFactory.Unknown (0 ms)
[----------] 6 tests from BuildersFactory (8 ms total)

[----------] 9 tests from BulkStringBuilder
[ RUN      ] BulkStringBuilder.WithNoData
[       OK ] BulkStringBuilder.WithNoData (0 ms)
[ RUN      ] BulkStringBuilder.WithNotEnoughData
[       OK ] BulkStringBuilder.WithNotEnoughData (0 ms)
[ RUN      ] BulkStringBuilder.WithPartOfEndSequence
[       OK ] BulkStringBuilder.WithPartOfEndSequence (0 ms)
[ RUN      ] BulkStringBuilder.Null
[       OK ] BulkStringBuilder.Null (0 ms)
[ RUN      ] BulkStringBuilder.WithAllInOneTime
[       OK ] BulkStringBuilder.WithAllInOneTime (0 ms)
[ RUN      ] BulkStringBuilder.WithAllInMultipleTimes
[       OK ] BulkStringBuilder.WithAllInMultipleTimes (0 ms)
[ RUN      ] BulkStringBuilder.WithAllInMultipleTimes2
[       OK ] BulkStringBuilder.WithAllInMultipleTimes2 (0 ms)
[ RUN      ] BulkStringBuilder.WithAllInMultipleTimes3
[       OK ] BulkStringBuilder.WithAllInMultipleTimes3 (0 ms)
[ RUN      ] BulkStringBuilder.InvalidEndSequence
[       OK ] BulkStringBuilder.InvalidEndSequence (0 ms)
[----------] 9 tests from BulkStringBuilder (8 ms total)

[----------] 7 tests from ErrorBuilder
[ RUN      ] ErrorBuilder.WithNoData
[       OK ] ErrorBuilder.WithNoData (0 ms)
[ RUN      ] ErrorBuilder.WithNotEnoughData
[       OK ] ErrorBuilder.WithNotEnoughData (0 ms)
[ RUN      ] ErrorBuilder.WithPartOfEndSequence
[       OK ] ErrorBuilder.WithPartOfEndSequence (0 ms)
[ RUN      ] ErrorBuilder.WithAllInOneTime
[       OK ] ErrorBuilder.WithAllInOneTime (0 ms)
[ RUN      ] ErrorBuilder.WithAllInMultipleTimes
[       OK ] ErrorBuilder.WithAllInMultipleTimes (0 ms)
[ RUN      ] ErrorBuilder.WithAllInMultipleTimes2
[       OK ] ErrorBuilder.WithAllInMultipleTimes2 (0 ms)
[ RUN      ] ErrorBuilder.WithAllInMultipleTimes3
[       OK ] ErrorBuilder.WithAllInMultipleTimes3 (0 ms)
[----------] 7 tests from ErrorBuilder (8 ms total)

[----------] 10 tests from IntegerBuilder
[ RUN      ] IntegerBuilder.WithNoData
[       OK ] IntegerBuilder.WithNoData (0 ms)
[ RUN      ] IntegerBuilder.WithNotEnoughData
[       OK ] IntegerBuilder.WithNotEnoughData (0 ms)
[ RUN      ] IntegerBuilder.WithPartOfEndSequence
[       OK ] IntegerBuilder.WithPartOfEndSequence (0 ms)
[ RUN      ] IntegerBuilder.WithAllInOneTime
[       OK ] IntegerBuilder.WithAllInOneTime (0 ms)
[ RUN      ] IntegerBuilder.With64BitInteger
[       OK ] IntegerBuilder.With64BitInteger (0 ms)
[ RUN      ] IntegerBuilder.NegativeNumber
[       OK ] IntegerBuilder.NegativeNumber (0 ms)
[ RUN      ] IntegerBuilder.WithAllInMultipleTimes
[       OK ] IntegerBuilder.WithAllInMultipleTimes (0 ms)
[ RUN      ] IntegerBuilder.WithAllInMultipleTimes2
[       OK ] IntegerBuilder.WithAllInMultipleTimes2 (0 ms)
[ RUN      ] IntegerBuilder.WithAllInMultipleTimes3
[       OK ] IntegerBuilder.WithAllInMultipleTimes3 (0 ms)
[ RUN      ] IntegerBuilder.WrongChar
[       OK ] IntegerBuilder.WrongChar (0 ms)
[----------] 10 tests from IntegerBuilder (13 ms total)

[----------] 5 tests from ReplyBuilder
[ RUN      ] ReplyBuilder.WithNoData
[       OK ] ReplyBuilder.WithNoData (0 ms)
[ RUN      ] ReplyBuilder.WithNotEnoughData
[       OK ] ReplyBuilder.WithNotEnoughData (0 ms)
[ RUN      ] ReplyBuilder.WithPartOfEndSequence
[       OK ] ReplyBuilder.WithPartOfEndSequence (0 ms)
[ RUN      ] ReplyBuilder.WithAllInOneTime
[       OK ] ReplyBuilder.WithAllInOneTime (0 ms)
[ RUN      ] ReplyBuilder.WithAllInMultipleTimes
[       OK ] ReplyBuilder.WithAllInMultipleTimes (0 ms)
[----------] 5 tests from ReplyBuilder (4 ms total)

[----------] 7 tests from SimpleStringBuilder
[ RUN      ] SimpleStringBuilder.WithNoData
[       OK ] SimpleStringBuilder.WithNoData (0 ms)
[ RUN      ] SimpleStringBuilder.WithNotEnoughData
[       OK ] SimpleStringBuilder.WithNotEnoughData (0 ms)
[ RUN      ] SimpleStringBuilder.WithPartOfEndSequence
[       OK ] SimpleStringBuilder.WithPartOfEndSequence (0 ms)
[ RUN      ] SimpleStringBuilder.WithAllInOneTime
[       OK ] SimpleStringBuilder.WithAllInOneTime (0 ms)
[ RUN      ] SimpleStringBuilder.WithAllInMultipleTimes
[       OK ] SimpleStringBuilder.WithAllInMultipleTimes (0 ms)
[ RUN      ] SimpleStringBuilder.WithAllInMultipleTimes2
[       OK ] SimpleStringBuilder.WithAllInMultipleTimes2 (1 ms)
[ RUN      ] SimpleStringBuilder.WithAllInMultipleTimes3
[       OK ] SimpleStringBuilder.WithAllInMultipleTimes3 (1 ms)
[----------] 7 tests from SimpleStringBuilder (8 ms total)

[----------] Global test environment tear-down
[==========] 111 tests from 10 test cases ran. (10362 ms total)
[  PASSED  ] 111 tests.
```