### PR TITLE
Fix std::atomic compilation errors (C2797) on msvc 2013 (again)

### DIFF
--- a/examples/redis_subscriber.cpp
+++ b/examples/redis_subscriber.cpp
@@ -29,7 +29,7 @@
 #include <Winsock2.h>
 #endif /* _WIN32 */
 
-volatile std::atomic_bool should_exit = ATOMIC_VAR_INIT(false);
+volatile std::atomic<bool> should_exit = ATOMIC_VAR_INIT(false);
 
 void
 sigint_handler(int) {

--- a/includes/cpp_redis/redis_client.hpp
+++ b/includes/cpp_redis/redis_client.hpp
@@ -308,7 +308,7 @@ private:
   std::mutex m_callbacks_mutex;
   std::mutex m_send_mutex;
   std::condition_variable m_sync_condvar;
-  std::atomic_uint m_callbacks_running = ATOMIC_VAR_INIT(0);
+  std::atomic<unsigned int> m_callbacks_running = ATOMIC_VAR_INIT(0);
 };
 
 } //! cpp_redis

--- a/tests/sources/spec/redis_client_spec.cpp
+++ b/tests/sources/spec/redis_client_spec.cpp
@@ -121,7 +121,7 @@ TEST(RedisClient, SyncCommitTimeout) {
   cpp_redis::redis_client client;
 
   client.connect();
-  volatile std::atomic_bool callback_exit = ATOMIC_VAR_INIT(false);
+  volatile std::atomic<bool> callback_exit = ATOMIC_VAR_INIT(false);
   client.send({"GET", "HELLO"}, [&](cpp_redis::reply&) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     callback_exit = true;
@@ -136,7 +136,7 @@ TEST(RedisClient, SyncCommitNoTimeout) {
   cpp_redis::redis_client client;
 
   client.connect();
-  std::atomic_bool callback_exit = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_exit = ATOMIC_VAR_INIT(false);
   client.send({"GET", "HELLO"}, [&](cpp_redis::reply&) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     callback_exit = true;
@@ -163,7 +163,7 @@ TEST(RedisClient, SendConnectedSyncCommitConnected) {
 
   client.connect();
 
-  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_run = ATOMIC_VAR_INIT(false);
   client.send({"GET", "HELLO"}, [&](cpp_redis::reply&) {
     callback_run = true;
   });
@@ -175,7 +175,7 @@ TEST(RedisClient, SendConnectedSyncCommitConnected) {
 TEST(RedisClient, SendNotConnectedSyncCommitConnected) {
   cpp_redis::redis_client client;
 
-  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_run = ATOMIC_VAR_INIT(false);
   client.send({"GET", "HELLO"}, [&](cpp_redis::reply&) {
     callback_run = true;
   });
@@ -188,7 +188,7 @@ TEST(RedisClient, SendNotConnectedSyncCommitConnected) {
 TEST(RedisClient, SendNotConnectedSyncCommitNotConnectedSyncCommitConnected) {
   cpp_redis::redis_client client;
 
-  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_run = ATOMIC_VAR_INIT(false);
   client.send({"GET", "HELLO"}, [&](cpp_redis::reply&) {
     callback_run = true;
   });
@@ -259,7 +259,7 @@ TEST(RedisClient, DisconnectionHandlerWithQuit) {
   cpp_redis::redis_client client;
   std::condition_variable cv;
 
-  std::atomic_bool disconnection_handler_called = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> disconnection_handler_called = ATOMIC_VAR_INIT(false);
   client.connect("127.0.0.1", 6379, [&](cpp_redis::redis_client&) {
     disconnection_handler_called = true;
     cv.notify_all();
@@ -279,7 +279,7 @@ TEST(RedisClient, DisconnectionHandlerWithoutQuit) {
   cpp_redis::redis_client client;
   std::condition_variable cv;
 
-  std::atomic_bool disconnection_handler_called = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> disconnection_handler_called = ATOMIC_VAR_INIT(false);
   client.connect("127.0.0.1", 6379, [&](cpp_redis::redis_client&) {
     disconnection_handler_called = true;
     cv.notify_all();

--- a/tests/sources/spec/redis_subscriber_spec.cpp
+++ b/tests/sources/spec/redis_subscriber_spec.cpp
@@ -152,7 +152,7 @@ TEST(RedisSubscriber, SubConnectedCommitConnected) {
   sub.connect();
   client.connect();
 
-  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_run = ATOMIC_VAR_INIT(false);
   sub.subscribe("/chan",
     [&](const std::string&, const std::string&) {
       callback_run = true;
@@ -179,7 +179,7 @@ TEST(RedisSubscriber, SubNotConnectedCommitConnected) {
 
   client.connect();
 
-  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_run = ATOMIC_VAR_INIT(false);
   sub.subscribe("/chan",
     [&](const std::string&, const std::string&) {
       callback_run = true;
@@ -206,7 +206,7 @@ TEST(RedisSubscriber, SubNotConnectedCommitNotConnectedCommitConnected) {
 
   client.connect();
 
-  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_run = ATOMIC_VAR_INIT(false);
   sub.subscribe("/chan",
     [&](const std::string&, const std::string&) {
       callback_run = true;
@@ -233,7 +233,7 @@ TEST(RedisSubscriber, SubscribeSomethingPublished) {
   sub.connect();
   client.connect();
 
-  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_run = ATOMIC_VAR_INIT(false);
   sub.subscribe("/chan",
     [&](const std::string& channel, const std::string& message) {
       EXPECT_TRUE(channel == "/chan");
@@ -263,7 +263,7 @@ TEST(RedisSubscriber, SubscribeMultiplePublished) {
   sub.connect();
   client.connect();
 
-  std::atomic_int number_times_called = ATOMIC_VAR_INIT(0);
+  std::atomic<int> number_times_called = ATOMIC_VAR_INIT(0);
   sub.subscribe("/chan",
     [&](const std::string& channel, const std::string& message) {
       EXPECT_TRUE(channel == "/chan");
@@ -296,7 +296,7 @@ TEST(RedisSubscriber, SubscribeNothingPublished) {
   sub.connect();
   client.connect();
 
-  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_run = ATOMIC_VAR_INIT(false);
   sub.subscribe("/chan",
     [&](const std::string&, const std::string&) {
       callback_run = true;
@@ -329,8 +329,8 @@ TEST(RedisSubscriber, MultipleSubscribeSomethingPublished) {
     }
   };
 
-  std::atomic_bool callback_1_run = ATOMIC_VAR_INIT(false);
-  std::atomic_bool callback_2_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_1_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_2_run = ATOMIC_VAR_INIT(false);
   sub.subscribe("/chan_1",
     [&](const std::string& channel, const std::string& message) {
       EXPECT_TRUE(channel == "/chan_1");
@@ -370,7 +370,7 @@ TEST(RedisSubscriber, PSubscribeSomethingPublished) {
   sub.connect();
   client.connect();
 
-  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_run = ATOMIC_VAR_INIT(false);
   sub.psubscribe("/chan/*",
     [&](const std::string& channel, const std::string& message) {
       EXPECT_TRUE(channel == "/chan/hello");
@@ -400,7 +400,7 @@ TEST(RedisSubscriber, PSubscribeMultiplePublished) {
   sub.connect();
   client.connect();
 
-  std::atomic_int number_times_called = ATOMIC_VAR_INIT(0);
+  std::atomic<int> number_times_called = ATOMIC_VAR_INIT(0);
   sub.psubscribe("/chan/*",
     [&](const std::string& channel, const std::string& message) {
       ++number_times_called;
@@ -440,7 +440,7 @@ TEST(RedisSubscriber, PSubscribeNothingPublished) {
   sub.connect();
   client.connect();
 
-  std::atomic_bool callback_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_run = ATOMIC_VAR_INIT(false);
   sub.psubscribe("/chan/*",
     [&](const std::string&, const std::string&) {
       callback_run = true;
@@ -473,8 +473,8 @@ TEST(RedisSubscriber, MultiplePSubscribeSomethingPublished) {
     }
   };
 
-  std::atomic_bool callback_1_run = ATOMIC_VAR_INIT(false);
-  std::atomic_bool callback_2_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_1_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_2_run = ATOMIC_VAR_INIT(false);
   sub.psubscribe("/chan/*",
     [&](const std::string& channel, const std::string& message) {
       EXPECT_TRUE(channel == "/chan/1");
@@ -522,8 +522,8 @@ TEST(RedisSubscriber, Unsubscribe) {
     }
   };
 
-  std::atomic_bool callback_1_run = ATOMIC_VAR_INIT(false);
-  std::atomic_bool callback_2_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_1_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_2_run = ATOMIC_VAR_INIT(false);
   sub.subscribe("/chan_1",
     [&](const std::string&, const std::string&) {
       callback_1_run = true;
@@ -563,8 +563,8 @@ TEST(RedisSubscriber, PUnsubscribe) {
     }
   };
 
-  std::atomic_bool callback_1_run = ATOMIC_VAR_INIT(false);
-  std::atomic_bool callback_2_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_1_run = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> callback_2_run = ATOMIC_VAR_INIT(false);
   sub.psubscribe("/chan_1/*",
     [&](const std::string&, const std::string&) {
       callback_1_run = true;


### PR DESCRIPTION
Avoid using typedef names over full specialization.

Same as mentioned in [tacopie](https://github.com/Cylix/tacopie/pull/3).

It has been also tested on VS 2013 and 2015.

[]'s