### PR TITLE
Fix release 3.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,9 +79,7 @@ ENDIF (WIN32)
 set(CPP_REDIS_INCLUDES ${PROJECT_SOURCE_DIR}/includes)
 set(DEPS_INCLUDES ${PROJECT_SOURCE_DIR}/deps/include)
 set(DEPS_LIBRARIES ${PROJECT_SOURCE_DIR}/deps/lib)
-IF ("${USE_TACOPIE}" STREQUAL "")
-  set(USE_TACOPIE "true")
-ENDIF ()
+
 
 ###
 # includes
@@ -103,9 +101,9 @@ foreach(dir ${SRC_DIRS})
   set(SOURCES ${SOURCES} ${s_${dir}} ${h_${dir}} ${i_${dir}})
 endforeach()
 # filter tcp_client if no tacopie
-IF (NOT USE_TACOPIE)
+IF (USE_CUSTOM_TCP_CLIENT)
   list(REMOVE_ITEM SRC_DIRS "source/network/tcp_client.cpp" "include/cpp_redis/network/tcp_client.hpp")
-ENDIF (NOT USE_TACOPIE)
+ENDIF (USE_CUSTOM_TCP_CLIENT)
 
 
 ###
@@ -142,10 +140,10 @@ IF (LOGGING_ENABLED)
   set_target_properties(${PROJECT} PROPERTIES COMPILE_DEFINITIONS "__CPP_REDIS_LOGGING_ENABLED=${LOGGING_ENABLED}")
 ENDIF (LOGGING_ENABLED)
 
-# __CPP_REDIS_USE_TACOPIE
-IF (USE_TACOPIE)
-  set_target_properties(${PROJECT} PROPERTIES COMPILE_DEFINITIONS "__CPP_REDIS_USE_TACOPIE=${USE_TACOPIE}")
-ENDIF (USE_TACOPIE)
+# __CPP_REDIS_USE_CUSTOM_TCP_CLIENT
+IF (USE_CUSTOM_TCP_CLIENT)
+  set_target_properties(${PROJECT} PROPERTIES COMPILE_DEFINITIONS "__CPP_REDIS_USE_CUSTOM_TCP_CLIENT=${USE_CUSTOM_TCP_CLIENT}")
+ENDIF (USE_CUSTOM_TCP_CLIENT)
 
 
 ###
@@ -163,12 +161,12 @@ install (DIRECTORY ${CPP_REDIS_INCLUDES}/ DESTINATION include USE_SOURCE_PERMISS
 ###
 # tacopie
 ###
-IF (USE_TACOPIE)
+IF (NOT USE_CUSTOM_TCP_CLIENT)
   ExternalProject_Add("tacopie"
                       GIT_SUBMODULES ""
                       CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${PROJECT_SOURCE_DIR}/deps"
                       SOURCE_DIR "${PROJECT_SOURCE_DIR}/tacopie")
-ENDIF (USE_TACOPIE)
+ENDIF (NOT USE_CUSTOM_TCP_CLIENT)
 
 
 ###

--- a/includes/cpp_redis/future_client.hpp
+++ b/includes/cpp_redis/future_client.hpp
@@ -27,6 +27,7 @@
 #include <memory>
 
 #include <cpp_redis/logger.hpp>
+#include <cpp_redis/network/tcp_client_iface.hpp>
 #include <cpp_redis/redis_client.hpp>
 
 namespace cpp_redis {
@@ -59,8 +60,12 @@ private:
   }
 
 public:
-  //! ctor & dtor
-  future_client(void)  = default;
+//! ctor & dtor
+#ifndef __CPP_REDIS_USE_CUSTOM_TCP_CLIENT
+  future_client(void) = default;
+#endif /* __CPP_REDIS_USE_CUSTOM_TCP_CLIENT */
+  explicit future_client(const std::shared_ptr<network::tcp_client_iface>& tcp_client)
+  : m_client(tcp_client) {}
   ~future_client(void) = default;
 
   void

--- a/includes/cpp_redis/network/redis_connection.hpp
+++ b/includes/cpp_redis/network/redis_connection.hpp
@@ -41,8 +41,11 @@ namespace network {
 
 class redis_connection {
 public:
-  //! ctor & dtor
+//! ctor & dtor
+#ifndef __CPP_REDIS_USE_CUSTOM_TCP_CLIENT
   redis_connection(void);
+#endif /* __CPP_REDIS_USE_CUSTOM_TCP_CLIENT */
+  explicit redis_connection(const std::shared_ptr<tcp_client_iface>& tcp_client);
   ~redis_connection(void);
 
   //! copy ctor & assignment operator
@@ -94,8 +97,6 @@ private:
   //! protect internal buffer against race conditions
   std::mutex m_buffer_mutex;
 };
-
-extern std::function<std::shared_ptr<tcp_client_iface>()> get_tcp_client;
 
 } //! network
 

--- a/includes/cpp_redis/redis_client.hpp
+++ b/includes/cpp_redis/redis_client.hpp
@@ -32,13 +32,17 @@
 
 #include <cpp_redis/logger.hpp>
 #include <cpp_redis/network/redis_connection.hpp>
+#include <cpp_redis/network/tcp_client_iface.hpp>
 
 namespace cpp_redis {
 
 class redis_client {
 public:
-  //! ctor & dtor
+//! ctor & dtor
+#ifndef __CPP_REDIS_USE_CUSTOM_TCP_CLIENT
   redis_client(void);
+#endif /* __CPP_REDIS_USE_CUSTOM_TCP_CLIENT */
+  explicit redis_client(const std::shared_ptr<network::tcp_client_iface>& tcp_client);
   ~redis_client(void);
 
   //! copy ctor & assignment operator

--- a/includes/cpp_redis/redis_subscriber.hpp
+++ b/includes/cpp_redis/redis_subscriber.hpp
@@ -28,13 +28,17 @@
 #include <string>
 
 #include <cpp_redis/network/redis_connection.hpp>
+#include <cpp_redis/network/tcp_client_iface.hpp>
 
 namespace cpp_redis {
 
 class redis_subscriber {
 public:
-  //! ctor & dtor
+//! ctor & dtor
+#ifndef __CPP_REDIS_USE_CUSTOM_TCP_CLIENT
   redis_subscriber(void);
+#endif /* __CPP_REDIS_USE_CUSTOM_TCP_CLIENT */
+  explicit redis_subscriber(const std::shared_ptr<network::tcp_client_iface>& tcp_client);
   ~redis_subscriber(void);
 
   //! copy ctor & assignment operator

--- a/sources/network/redis_connection.cpp
+++ b/sources/network/redis_connection.cpp
@@ -24,24 +24,22 @@
 #include <cpp_redis/network/redis_connection.hpp>
 #include <cpp_redis/redis_error.hpp>
 
-#ifdef __CPP_REDIS_USE_TACOPIE
+#ifndef __CPP_REDIS_USE_CUSTOM_TCP_CLIENT
 #include <cpp_redis/network/tcp_client.hpp>
-#endif /* __CPP_REDIS_USE_TACOPIE */
+#endif /* __CPP_REDIS_USE_CUSTOM_TCP_CLIENT */
 
 namespace cpp_redis {
 
 namespace network {
 
-std::function<std::shared_ptr<tcp_client_iface>()> get_tcp_client = []() -> std::shared_ptr<tcp_client_iface> {
-#ifdef __CPP_REDIS_USE_TACOPIE
-  return std::make_shared<tcp_client>();
-#else
-  return nullptr;
-#endif /* __CPP_REDIS_USE_TACOPIE */
-};
-
+#ifndef __CPP_REDIS_USE_CUSTOM_TCP_CLIENT
 redis_connection::redis_connection(void)
-: m_client(get_tcp_client())
+: redis_connection(std::make_shared<tcp_client>()) {
+}
+#endif /* __CPP_REDIS_USE_CUSTOM_TCP_CLIENT */
+
+redis_connection::redis_connection(const std::shared_ptr<tcp_client_iface>& client)
+: m_client(client)
 , m_reply_callback(nullptr)
 , m_disconnection_handler(nullptr) {
   __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection created");

--- a/sources/redis_client.cpp
+++ b/sources/redis_client.cpp
@@ -25,7 +25,14 @@
 
 namespace cpp_redis {
 
+#ifndef __CPP_REDIS_USE_CUSTOM_TCP_CLIENT
 redis_client::redis_client(void) {
+  __CPP_REDIS_LOG(debug, "cpp_redis::redis_client created");
+}
+#endif /* __CPP_REDIS_USE_CUSTOM_TCP_CLIENT */
+
+redis_client::redis_client(const std::shared_ptr<network::tcp_client_iface>& tcp_client)
+: m_client(tcp_client) {
   __CPP_REDIS_LOG(debug, "cpp_redis::redis_client created");
 }
 

--- a/sources/redis_subscriber.cpp
+++ b/sources/redis_subscriber.cpp
@@ -26,8 +26,16 @@
 
 namespace cpp_redis {
 
+#ifndef __CPP_REDIS_USE_CUSTOM_TCP_CLIENT
 redis_subscriber::redis_subscriber(void)
 : m_auth_reply_callback(nullptr) {
+  __CPP_REDIS_LOG(debug, "cpp_redis::redis_subscriber created");
+}
+#endif /* __CPP_REDIS_USE_CUSTOM_TCP_CLIENT */
+
+redis_subscriber::redis_subscriber(const std::shared_ptr<network::tcp_client_iface>& tcp_client)
+: m_client(tcp_client)
+, m_auth_reply_callback(nullptr) {
   __CPP_REDIS_LOG(debug, "cpp_redis::redis_subscriber created");
 }
 


### PR DESCRIPTION
Fix a bug introduced in release 3.2.0 and reported in #61 .

The bug occurs when a `redis_client` or a `redis_subscriber` is initialized as a global data.
It introduced a static initialization order fiasco condition due to a conflict between the initialization of the `redis_client` and the initialization of an internal global variable, `get_tcp_client`, which is supposed to be used during the initialization.

In order to solve that, the design has been reviewed in order to not use the global variable `get_tcp_client`, but instead an additional constructor in `redis_client` and `redis_subscriber` (and forward that parameter to the `redis_connection` where the issue occurs).

These additional constructors are only provided for the very specific case where the user do not wish to use `tacopie` as the network library and wants to provide its own TCP client implementation.

I also renamed a define from `__CPP_REDIS_USE_TACOPIE` (cmake variable: `USE_TACOPIE`) into `__CPP_REDIS_USE_CUSTOM_TCP_CLIENT` (cmake variable: `USE_CUSTOM_TCP_CLIENT`).
This change should not impact anyone since `__CPP_REDIS_USE_TACOPIE` has been introduced only yesterday and has not been documented yet.

Since the 3.2.0 has been released yesterday, only few people might have been impacted by the bug.