### PR TITLE
Produce and install PDB (debug symbols) on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,9 @@ configure_file("cpp_redis.pc.in" "${CMAKE_PKGCONFIG_OUTPUT_DIRECTORY}/cpp_redis.
 # executable
 ###
 add_library(${PROJECT} STATIC ${SOURCES})
+set_target_properties(${PROJECT} PROPERTIES COMPILE_PDB_NAME ${PROJECT}
+  COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+)
 
 IF (WIN32)
   target_link_libraries(${PROJECT} ws2_32 tacopie)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,9 +123,12 @@ configure_file("cpp_redis.pc.in" "${CMAKE_PKGCONFIG_OUTPUT_DIRECTORY}/cpp_redis.
 # executable
 ###
 add_library(${PROJECT} STATIC ${SOURCES})
-set_target_properties(${PROJECT} PROPERTIES COMPILE_PDB_NAME ${PROJECT}
-  COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
-)
+
+if (WIN32)
+  set_target_properties(${PROJECT}
+                        PROPERTIES COMPILE_PDB_NAME ${PROJECT}
+                        COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+ENDIF (WIN32)
 
 IF (WIN32)
   target_link_libraries(${PROJECT} ws2_32 tacopie)


### PR DESCRIPTION
Useful for CMake configs like "Debug" or "RelWithDebInfo". It avoids a
MSVC warning when one tries to link to the library from an own project.