### PR TITLE
Fix reconnect behavior

### DIFF
--- a/sources/network/redis_connection.cpp
+++ b/sources/network/redis_connection.cpp
@@ -100,6 +100,9 @@ redis_connection::build_command(const std::vector<std::string>& redis_cmd) {
 
 redis_connection&
 redis_connection::send(const std::vector<std::string>& redis_cmd) {
+  if (not is_connected())
+    throw redis_error("Client is disconnected");
+
   std::lock_guard<std::mutex> lock(m_buffer_mutex);
 
   m_buffer += build_command(redis_cmd);

--- a/sources/network/redis_connection.cpp
+++ b/sources/network/redis_connection.cpp
@@ -100,9 +100,6 @@ redis_connection::build_command(const std::vector<std::string>& redis_cmd) {
 
 redis_connection&
 redis_connection::send(const std::vector<std::string>& redis_cmd) {
-  if (not is_connected())
-    throw redis_error("Client is disconnected");
-
   std::lock_guard<std::mutex> lock(m_buffer_mutex);
 
   m_buffer += build_command(redis_cmd);
@@ -125,6 +122,7 @@ redis_connection::commit(void) {
     m_client->async_write(request);
   }
   catch (const std::exception& e) {
+    m_buffer = std::move(buffer);
     __CPP_REDIS_LOG(error, std::string("cpp_redis::network::redis_connection ") + e.what());
     throw redis_error(e.what());
   }

--- a/sources/redis_client.cpp
+++ b/sources/redis_client.cpp
@@ -126,10 +126,10 @@ redis_client::connection_receive_handler(network::redis_connection&, reply& repl
   __CPP_REDIS_LOG(info, "cpp_redis::redis_client received reply");
   {
     std::lock_guard<std::mutex> lock(m_callbacks_mutex);
+    m_callbacks_running += 1;
 
     if (m_callbacks.size()) {
       callback = m_callbacks.front();
-      m_callbacks_running += 1;
       m_callbacks.pop();
     }
   }

--- a/sources/redis_client.cpp
+++ b/sources/redis_client.cpp
@@ -114,7 +114,6 @@ redis_client::try_commit(void) {
   }
   catch (const cpp_redis::redis_error& e) {
     __CPP_REDIS_LOG(error, "cpp_redis::redis_client could not send pipelined commands");
-    clear_callbacks();
     throw e;
   }
 }

--- a/tests/sources/spec/redis_subscriber_spec.cpp
+++ b/tests/sources/spec/redis_subscriber_spec.cpp
@@ -225,7 +225,7 @@ TEST(RedisSubscriber, SubNotConnectedCommitNotConnectedCommitConnected) {
 
   std::this_thread::sleep_for(std::chrono::seconds(2));
 
-  EXPECT_FALSE(callback_run);
+  EXPECT_TRUE(callback_run);
 }
 
 TEST(RedisSubscriber, SubscribeSomethingPublished) {


### PR DESCRIPTION
Fix issue #70.

* update ref to tacopie (fix reconnection issue)
* do not clear buffered commands/callbacks when trying to commit/sync_commit during disconnection (more convenient and consistent with .send behavior)
* fix deadlock issue on .sycn_commit during reconnection
* update tests to reflect changes