### PR TITLE
To avoid compile error when `DBUILD_EXAMPLES=true`.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,7 +24,7 @@
 # compilation options
 ###
 IF (NOT WIN32)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++11")
 ENDIF (NOT WIN32)
 
 


### PR DESCRIPTION
Add `-pthread` flag to `CMAKE_CXX_FLAGS`, otherwise, when set  `DBUILD_EXAMPLES=true`, there would be compile error.

```
/usr/local/lib/libtacopie.a(io_service.cpp.o): In function `tacopie::io_service::io_service()':
io_service.cpp:(.text+0xac1): undefined reference to `pthread_create'
/usr/local/lib/libtacopie.a(thread_pool.cpp.o): In function `tacopie::utils::thread_pool::thread_pool(unsigned long)':
thread_pool.cpp:(.text+0x88b): undefined reference to `pthread_create'
collect2: error: ld returned 1 exit status
examples/CMakeFiles/cpp_redis_subscriber.dir/build.make:96: recipe for target 'bin/cpp_redis_subscriber' failed
make[2]: *** [bin/cpp_redis_subscriber] Error 1
CMakeFiles/Makefile2:167: recipe for target 'examples/CMakeFiles/cpp_redis_subscriber.dir/all' failed
make[1]: *** [examples/CMakeFiles/cpp_redis_subscriber.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
```