### PR TITLE
fixed zadd to take multimap instead of map

### DIFF
--- a/includes/cpp_redis/future_client.hpp
+++ b/includes/cpp_redis/future_client.hpp
@@ -261,7 +261,7 @@ public:
   future unwatch();
   future wait(int numslaves, int timeout);
   future watch(const std::vector<std::string>& keys);
-  future zadd(const std::string& key, const std::vector<std::string>& options, const std::map<std::string, std::string>& score_members);
+  future zadd(const std::string& key, const std::vector<std::string>& options, const std::multimap<std::string, std::string>& score_members);
   future zcard(const std::string& key);
   future zcount(const std::string& key, int min, int max);
   future zcount(const std::string& key, double min, double max);

--- a/includes/cpp_redis/redis_client.hpp
+++ b/includes/cpp_redis/redis_client.hpp
@@ -279,7 +279,7 @@ public:
   redis_client& unwatch(const reply_callback_t& reply_callback = nullptr);
   redis_client& wait(int numslaves, int timeout, const reply_callback_t& reply_callback = nullptr);
   redis_client& watch(const std::vector<std::string>& keys, const reply_callback_t& reply_callback = nullptr);
-  redis_client& zadd(const std::string& key, const std::vector<std::string>& options, const std::map<std::string, std::string>& score_members, const reply_callback_t& reply_callback = nullptr);
+  redis_client& zadd(const std::string& key, const std::vector<std::string>& options, const std::multimap<std::string, std::string>& score_members, const reply_callback_t& reply_callback = nullptr);
   redis_client& zcard(const std::string& key, const reply_callback_t& reply_callback = nullptr);
   redis_client& zcount(const std::string& key, int min, int max, const reply_callback_t& reply_callback = nullptr);
   redis_client& zcount(const std::string& key, double min, double max, const reply_callback_t& reply_callback = nullptr);

--- a/sources/future_client.cpp
+++ b/sources/future_client.cpp
@@ -947,7 +947,7 @@ future_client::watch(const std::vector<std::string>& keys) {
 }
 
 future_client::future
-future_client::zadd(const std::string& key, const std::vector<std::string>& options, const std::map<std::string, std::string>& score_members) {
+future_client::zadd(const std::string& key, const std::vector<std::string>& options, const std::multimap<std::string, std::string>& score_members) {
   return exec_cmd([=](const rcb_t& cb) -> rc& { return m_client.zadd(key, options, score_members, cb); });
 }
 

--- a/sources/redis_client.cpp
+++ b/sources/redis_client.cpp
@@ -1339,7 +1339,7 @@ redis_client::watch(const std::vector<std::string>& keys, const reply_callback_t
 }
 
 redis_client&
-redis_client::zadd(const std::string& key, const std::vector<std::string>& options, const std::map<std::string, std::string>& score_members, const reply_callback_t& reply_callback) {
+redis_client::zadd(const std::string& key, const std::vector<std::string>& options, const std::multimap<std::string, std::string>& score_members, const reply_callback_t& reply_callback) {
   std::vector<std::string> cmd = {"ZADD", key};
 
   //! options


### PR DESCRIPTION
I installed cpp_redis and was doing some tests. I used `zadd` to make rankings of mine.
I have some data that has same score.
But in `zadd` of `cpp_redis`, it takes `std::map<score, member>` as an argument.
It seemed impossible to zadd data with same score in single command as the key of `std::map` is score.
Of course I can query several `zadd` commands for each data, but I think it would be more convenient and effiecient to query `zadd` many data in single command.
Therefore, I thought taking parameter as `std::multimap` would be better than taking them as `std::map`.