### PR TITLE
Remove explicit STATIC in add_library call so dynamic libraries can be built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ configure_file("cpp_redis.pc.in" "${CMAKE_PKGCONFIG_OUTPUT_DIRECTORY}/cpp_redis.
 ###
 # executable
 ###
-add_library(${PROJECT} STATIC ${SOURCES})
+add_library(${PROJECT} ${SOURCES})
 
 if (WIN32)
   set_target_properties(${PROJECT}


### PR DESCRIPTION
Should default to `STATIC`, and if shared libraries are desired, use the  `-DBUILD_SHARED_LIBS=ON` cmake option