### PR TITLE
reset the SOURCES var so that the tacopie project won't include the cpp_redis sources too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,5 +213,6 @@ endif(BUILD_TESTS)
 # tacopie
 ###
 if(NOT TACOPIE_LIBRARY AND NOT USE_CUSTOM_TCP_CLIENT)
+  set(SOURCES)  # reset the SOURCES var so that the tacopie project won't include the cpp_redis sources too
   add_subdirectory(tacopie)
 endif(NOT TACOPIE_LIBRARY AND NOT USE_CUSTOM_TCP_CLIENT)


### PR DESCRIPTION
found when `__CPP_REDIS_LOGGING_ENABLED` was set, but `__TACOPIE_LOGGING_ENABLED` was not, and we couldn't see any cpp_redis logs ...