### PR TITLE
Fix errors that appear when compiling with `-pedantic-errors` flag.

### DIFF
--- a/includes/cpp_redis/core/sentinel.hpp
+++ b/includes/cpp_redis/core/sentinel.hpp
@@ -344,4 +344,4 @@ private:
   std::atomic<unsigned int> m_callbacks_running;
 };
 
-}; // namespace cpp_redis
+} // namespace cpp_redis

--- a/includes/cpp_redis/impl/client.ipp
+++ b/includes/cpp_redis/impl/client.ipp
@@ -67,13 +67,13 @@ client::client_kill_impl(std::vector<std::string>& redis_cmd, reply_callback_t& 
   static_assert(!std::is_class<T>::value, "Reply callback should be in the end of the argument list");
   client_kill_unpack_arg<T>(redis_cmd, reply, arg);
   client_kill_impl(redis_cmd, reply, args...);
-};
+}
 
 template <typename T>
 void
 client::client_kill_impl(std::vector<std::string>& redis_cmd, reply_callback_t& reply, const T& arg) {
   client_kill_unpack_arg<T>(redis_cmd, reply, arg);
-};
+}
 
 template <typename T, typename... Ts>
 inline client&


### PR DESCRIPTION
Extra unnecessary semicolons removed.