### PR TITLE
Improve bulk_string_builder::operator<< method body

### DIFF
--- a/sources/builders/bulk_string_builder.cpp
+++ b/sources/builders/bulk_string_builder.cpp
@@ -79,11 +79,8 @@ bulk_string_builder::fetch_str(std::string& buffer) {
 
 builder_iface&
 bulk_string_builder::operator<<(std::string& buffer) {
-  if (m_reply_ready)
-    return *this;
-
   //! if we don't have the size, try to get it with the current buffer
-  if (!fetch_size(buffer) || m_reply_ready)
+  if (m_reply_ready || !fetch_size(buffer))
     return *this;
 
   fetch_str(buffer);


### PR DESCRIPTION
I have noticed that the implementation of `bulk_string_builder::operator<<` method can be simplified.