### PR TITLE
Fix redundant copy of caught exception

### DIFF
--- a/sources/core/client.cpp
+++ b/sources/core/client.cpp
@@ -215,11 +215,11 @@ client::try_commit(void) {
     m_client.commit();
     __CPP_REDIS_LOG(info, "cpp_redis::client sent pipelined commands");
   }
-  catch (const cpp_redis::redis_error& e) {
+  catch (const cpp_redis::redis_error&) {
     __CPP_REDIS_LOG(error, "cpp_redis::client could not send pipelined commands");
     //! ensure commands are flushed
     clear_callbacks();
-    throw e;
+    throw;
   }
 }
 

--- a/sources/core/sentinel.cpp
+++ b/sources/core/sentinel.cpp
@@ -276,10 +276,10 @@ sentinel::try_commit(void) {
     m_client.commit();
     __CPP_REDIS_LOG(info, "cpp_redis::sentinel sent pipelined commands");
   }
-  catch (const cpp_redis::redis_error& e) {
+  catch (const cpp_redis::redis_error&) {
     __CPP_REDIS_LOG(error, "cpp_redis::sentinel could not send pipelined commands");
     clear_callbacks();
-    throw e;
+    throw;
   }
 }
 

--- a/sources/core/subscriber.cpp
+++ b/sources/core/subscriber.cpp
@@ -252,9 +252,9 @@ subscriber::commit(void) {
     m_client.commit();
     __CPP_REDIS_LOG(info, "cpp_redis::subscriber sent pipelined commands");
   }
-  catch (const cpp_redis::redis_error& e) {
+  catch (const cpp_redis::redis_error&) {
     __CPP_REDIS_LOG(error, "cpp_redis::subscriber could not send pipelined commands");
-    throw e;
+    throw;
   }
 
   return *this;


### PR DESCRIPTION
Using [cppcheck](https://github.com/danmar/cppcheck) I have found redundant calls of copy constructors for caught exception during rethrowing.